### PR TITLE
Populer feltet medlemskapVurdering for søknadstype GRADERT_REISETILSKUDD

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/domain/mapper/SykepengesoknadTilSykepengesoknadDTOMapper.kt
+++ b/src/main/kotlin/no/nav/helse/flex/domain/mapper/SykepengesoknadTilSykepengesoknadDTOMapper.kt
@@ -89,7 +89,11 @@ class SykepengesoknadTilSykepengesoknadDTOMapper(
     }
 
     private fun SykepengesoknadDTO.merkMedMedlemskapStatus(): SykepengesoknadDTO {
-        if (type != SoknadstypeDTO.ARBEIDSTAKERE) {
+        if (!listOf(
+                SoknadstypeDTO.ARBEIDSTAKERE,
+                SoknadstypeDTO.GRADERT_REISETILSKUDD
+            ).contains(type)
+        ) {
             return this
         }
 

--- a/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/SoknadGenerering.kt
+++ b/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/SoknadGenerering.kt
@@ -21,9 +21,11 @@ fun erForsteSoknadIForlop(
     sykepengesoknad: Sykepengesoknad
 ): Boolean {
     return eksisterendeSoknader.asSequence()
-        // Finner søknader med samme arbeidssituasjon som, men med 'fom' før eller lik søknaden det sammenlignes med.
+        // Finner søknader med samme arbeidssituasjon som, men med 'fom' FØR eller LIK søknaden det sammenlignes med.
         .filter { it.fom != null && it.fom.isBeforeOrEqual(sykepengesoknad.fom!!) }
         .filter { it.sykmeldingId != null && it.startSykeforlop != null }
+        // Spørsmål om medlemskap vil bare bli stilt i for søknader med arbeidssituasjon.ARBEIDSTAKER, men det ingen
+        // gevinst i å eksplitt sjekke på det her.
         .filter { it.arbeidssituasjon == sykepengesoknad.arbeidssituasjon }
         // Sjekker om det finnes en tidligere søknad med samme startdato for sykeforløp.
         .none { it.startSykeforlop == sykepengesoknad.startSykeforlop }
@@ -41,12 +43,10 @@ fun harBlittStiltUtlandsSporsmal(
         .any { it -> it.sporsmal.any { it.tag == UTENLANDSK_SYKMELDING_BOSTED } }
 }
 
-// Finner søknader med samme arbeidssituasjon som, men med 'fom' før søknaden det sammenlignes med.
+// Finner søknader med samme arbeidssituasjon som, men med 'fom' FØR søknaden det sammenlignes med.
 private fun Sequence<Sykepengesoknad>.finnTidligereSoknaderMedSammeArbeidssituasjon(sykepengesoknad: Sykepengesoknad): Sequence<Sykepengesoknad> =
     this.filter { it.fom != null && it.fom.isBefore(sykepengesoknad.fom) }
         .filter { it.sykmeldingId != null && it.startSykeforlop != null }
-        // Spørsmål om medlemskap vil bare bli stilt i for søknader med arbeidssituasjon ARBEIDSTAKER, men det ingen
-        // gevinst i å eksplitt sjekke på det her.
         .filter { it.arbeidssituasjon == sykepengesoknad.arbeidssituasjon }
 
 // Om det er arbeidssituasjon ARBEIDSTAKER med søknadstype BEHANDLINGSDAGER, GRADERT_REISETILSKUD eller ARBEIDSTAKER

--- a/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapArbeidUtenforNorgeIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapArbeidUtenforNorgeIntegrationTest.kt
@@ -16,7 +16,6 @@ import no.nav.helse.flex.unleash.UNLEASH_CONTEXT_MEDLEMSKAP_SPORSMAL
 import no.nav.helse.flex.unleash.UNLEASH_CONTEXT_TIL_SLUTT_SPORSMAL
 import no.nav.helse.flex.util.serialisertTilString
 import okhttp3.mockwebserver.MockResponse
-import org.amshove.kluent.`should be equal to`
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -25,7 +24,6 @@ import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import java.time.LocalDate
-import java.util.concurrent.TimeUnit
 
 /**
  * Tester som verifiserer at spørsmålet om ARBEID_UTENFOR_NORGE blir stilt når
@@ -43,11 +41,6 @@ class MedlemskapArbeidUtenforNorgeIntegrationTest : BaseTestClass() {
     @AfterAll
     fun hentAlleKafkaMeldinger() {
         juridiskVurderingKafkaConsumer.hentProduserteRecords()
-    }
-
-    @AfterAll
-    fun sjekkAtAlleMockWebServerRequestsErKonsumert() {
-        assertThat(medlemskapMockWebServer.takeRequest(100, TimeUnit.MILLISECONDS)).isNull()
     }
 
     @Test
@@ -88,10 +81,6 @@ class MedlemskapArbeidUtenforNorgeIntegrationTest : BaseTestClass() {
             soknadId = hentSoknaderMetadata(fnr).first().id,
             fnr = fnr
         )
-
-        medlemskapMockWebServer.takeRequest().let {
-            it.headers["fnr"] `should be equal to` fnr
-        }
 
         assertThat(soknad.sporsmal!!.map { it.tag }).isEqualTo(
             listOf(
@@ -134,10 +123,6 @@ class MedlemskapArbeidUtenforNorgeIntegrationTest : BaseTestClass() {
                 )
             )
         )
-
-        medlemskapMockWebServer.takeRequest().let {
-            it.headers["fnr"] `should be equal to` fnr
-        }
 
         assertThat(soknader).hasSize(1)
         assertThat(soknader.last().type).isEqualTo(SoknadstypeDTO.ARBEIDSTAKERE)
@@ -198,10 +183,6 @@ class MedlemskapArbeidUtenforNorgeIntegrationTest : BaseTestClass() {
             fnr = fnr
         )
 
-        medlemskapMockWebServer.takeRequest().let {
-            it.headers["fnr"] `should be equal to` fnr
-        }
-
         assertThat(soknad.sporsmal!!.map { it.tag }).isEqualTo(
             listOf(
                 ANSVARSERKLARING,
@@ -249,10 +230,6 @@ class MedlemskapArbeidUtenforNorgeIntegrationTest : BaseTestClass() {
             soknadId = hentSoknaderMetadata(fnr).first().id,
             fnr = fnr
         )
-
-        medlemskapMockWebServer.takeRequest().let {
-            it.headers["fnr"] `should be equal to` fnr
-        }
 
         assertThat(soknad.sporsmal!!.map { it.tag }).isEqualTo(
             listOf(

--- a/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapArbeidUtenforNorgeIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapArbeidUtenforNorgeIntegrationTest.kt
@@ -16,6 +16,7 @@ import no.nav.helse.flex.unleash.UNLEASH_CONTEXT_MEDLEMSKAP_SPORSMAL
 import no.nav.helse.flex.unleash.UNLEASH_CONTEXT_TIL_SLUTT_SPORSMAL
 import no.nav.helse.flex.util.serialisertTilString
 import okhttp3.mockwebserver.MockResponse
+import org.amshove.kluent.`should be equal to`
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -24,6 +25,7 @@ import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import java.time.LocalDate
+import java.util.concurrent.TimeUnit
 
 /**
  * Tester som verifiserer at spørsmålet om ARBEID_UTENFOR_NORGE blir stilt når
@@ -33,7 +35,7 @@ import java.time.LocalDate
 class MedlemskapArbeidUtenforNorgeIntegrationTest : BaseTestClass() {
 
     @BeforeAll
-    fun configureUnleash() {
+    fun konfigurerUnleash() {
         fakeUnleash.resetAll()
         fakeUnleash.enable(UNLEASH_CONTEXT_MEDLEMSKAP_SPORSMAL, UNLEASH_CONTEXT_TIL_SLUTT_SPORSMAL)
     }
@@ -41,6 +43,11 @@ class MedlemskapArbeidUtenforNorgeIntegrationTest : BaseTestClass() {
     @AfterAll
     fun hentAlleKafkaMeldinger() {
         juridiskVurderingKafkaConsumer.hentProduserteRecords()
+    }
+
+    @AfterAll
+    fun sjekkAtAlleMockWebServerRequestsErKonsumert() {
+        assertThat(medlemskapMockWebServer.takeRequest(100, TimeUnit.MILLISECONDS)).isNull()
     }
 
     @Test
@@ -81,6 +88,10 @@ class MedlemskapArbeidUtenforNorgeIntegrationTest : BaseTestClass() {
             soknadId = hentSoknaderMetadata(fnr).first().id,
             fnr = fnr
         )
+
+        medlemskapMockWebServer.takeRequest().let {
+            it.headers["fnr"] `should be equal to` fnr
+        }
 
         assertThat(soknad.sporsmal!!.map { it.tag }).isEqualTo(
             listOf(
@@ -123,6 +134,10 @@ class MedlemskapArbeidUtenforNorgeIntegrationTest : BaseTestClass() {
                 )
             )
         )
+
+        medlemskapMockWebServer.takeRequest().let {
+            it.headers["fnr"] `should be equal to` fnr
+        }
 
         assertThat(soknader).hasSize(1)
         assertThat(soknader.last().type).isEqualTo(SoknadstypeDTO.ARBEIDSTAKERE)
@@ -183,6 +198,10 @@ class MedlemskapArbeidUtenforNorgeIntegrationTest : BaseTestClass() {
             fnr = fnr
         )
 
+        medlemskapMockWebServer.takeRequest().let {
+            it.headers["fnr"] `should be equal to` fnr
+        }
+
         assertThat(soknad.sporsmal!!.map { it.tag }).isEqualTo(
             listOf(
                 ANSVARSERKLARING,
@@ -230,6 +249,10 @@ class MedlemskapArbeidUtenforNorgeIntegrationTest : BaseTestClass() {
             soknadId = hentSoknaderMetadata(fnr).first().id,
             fnr = fnr
         )
+
+        medlemskapMockWebServer.takeRequest().let {
+            it.headers["fnr"] `should be equal to` fnr
+        }
 
         assertThat(soknad.sporsmal!!.map { it.tag }).isEqualTo(
             listOf(

--- a/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapArbeidUtenforNorgeIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapArbeidUtenforNorgeIntegrationTest.kt
@@ -1,0 +1,247 @@
+package no.nav.helse.flex.medlemskap
+
+import no.nav.helse.flex.BaseTestClass
+import no.nav.helse.flex.domain.Arbeidssituasjon
+import no.nav.helse.flex.hentProduserteRecords
+import no.nav.helse.flex.hentSoknad
+import no.nav.helse.flex.hentSoknaderMetadata
+import no.nav.helse.flex.sendSykmelding
+import no.nav.helse.flex.soknadsopprettelse.*
+import no.nav.helse.flex.soknadsopprettelse.sporsmal.medlemskap.medIndex
+import no.nav.helse.flex.sykepengesoknad.kafka.SoknadsstatusDTO
+import no.nav.helse.flex.sykepengesoknad.kafka.SoknadstypeDTO
+import no.nav.helse.flex.testdata.heltSykmeldt
+import no.nav.helse.flex.testdata.sykmeldingKafkaMessage
+import no.nav.helse.flex.unleash.UNLEASH_CONTEXT_MEDLEMSKAP_SPORSMAL
+import no.nav.helse.flex.unleash.UNLEASH_CONTEXT_TIL_SLUTT_SPORSMAL
+import no.nav.helse.flex.util.serialisertTilString
+import okhttp3.mockwebserver.MockResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import java.time.LocalDate
+
+/**
+ * Tester som verifiserer at spørsmålet om ARBEID_UTENFOR_NORGE blir stilt når
+ * det ikke stilles erstattende medlemskapspørsmål.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class MedlemskapArbeidUtenforNorgeIntegrationTest : BaseTestClass() {
+
+    @BeforeAll
+    fun configureUnleash() {
+        fakeUnleash.resetAll()
+        fakeUnleash.enable(UNLEASH_CONTEXT_MEDLEMSKAP_SPORSMAL, UNLEASH_CONTEXT_TIL_SLUTT_SPORSMAL)
+    }
+
+    @AfterAll
+    fun hentAlleKafkaMeldinger() {
+        juridiskVurderingKafkaConsumer.hentProduserteRecords()
+    }
+
+    @Test
+    @Order(1)
+    fun `Oppretter søknad med status UAVKLART som ikke skal ha ARBEID_UTENFOR_NORGE`() {
+        val fnr = "31111111111"
+        medlemskapMockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                MedlemskapVurderingResponse(
+                    svar = MedlemskapVurderingSvarType.UAVKLART,
+                    sporsmal = listOf(
+                        MedlemskapVurderingSporsmal.OPPHOLDSTILATELSE,
+                        MedlemskapVurderingSporsmal.ARBEID_UTENFOR_NORGE,
+                        MedlemskapVurderingSporsmal.OPPHOLD_UTENFOR_EØS_OMRÅDE,
+                        MedlemskapVurderingSporsmal.OPPHOLD_UTENFOR_NORGE
+                    )
+                ).serialisertTilString()
+            )
+        )
+
+        val soknader = sendSykmelding(
+            sykmeldingKafkaMessage(
+                arbeidssituasjon = Arbeidssituasjon.ARBEIDSTAKER,
+                fnr = fnr,
+                sykmeldingsperioder = heltSykmeldt(
+                    fom = LocalDate.of(2023, 1, 1),
+                    tom = LocalDate.of(2023, 1, 7)
+                )
+            )
+        )
+
+        assertThat(soknader).hasSize(1)
+        assertThat(soknader.last().type).isEqualTo(SoknadstypeDTO.ARBEIDSTAKERE)
+        assertThat(soknader.last().status).isEqualTo(SoknadsstatusDTO.NY)
+        assertThat(soknader.last().medlemskapVurdering).isEqualTo("UAVKLART")
+
+        val soknad = hentSoknad(
+            soknadId = hentSoknaderMetadata(fnr).first().id,
+            fnr = fnr
+        )
+
+        assertThat(soknad.sporsmal!!.map { it.tag }).isEqualTo(
+            listOf(
+                ANSVARSERKLARING,
+                TILBAKE_I_ARBEID,
+                FERIE_V2,
+                PERMISJON_V2,
+                medIndex(ARBEID_UNDERVEIS_100_PROSENT, 0),
+                ANDRE_INNTEKTSKILDER_V2,
+                MEDLEMSKAP_UTFORT_ARBEID_UTENFOR_NORGE,
+                MEDLEMSKAP_OPPHOLD_UTENFOR_NORGE,
+                MEDLEMSKAP_OPPHOLD_UTENFOR_EOS,
+                UTLAND_V2,
+                MEDLEMSKAP_OPPHOLDSTILLATELSE,
+                TIL_SLUTT
+            )
+        )
+    }
+
+    @Test
+    @Order(1)
+    fun `Oppretter søknad med status UAVKLART uten spørsmål fra LovMe som skal ha ARBEID_UTENFOR_NORGE`() {
+        val fnr = "31111111116"
+        medlemskapMockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                MedlemskapVurderingResponse(
+                    svar = MedlemskapVurderingSvarType.UAVKLART,
+                    sporsmal = emptyList()
+                ).serialisertTilString()
+            )
+        )
+
+        val soknader = sendSykmelding(
+            sykmeldingKafkaMessage(
+                arbeidssituasjon = Arbeidssituasjon.ARBEIDSTAKER,
+                fnr = fnr,
+                sykmeldingsperioder = heltSykmeldt(
+                    fom = LocalDate.of(2023, 1, 1),
+                    tom = LocalDate.of(2023, 1, 7)
+                )
+            )
+        )
+
+        assertThat(soknader).hasSize(1)
+        assertThat(soknader.last().type).isEqualTo(SoknadstypeDTO.ARBEIDSTAKERE)
+        assertThat(soknader.last().status).isEqualTo(SoknadsstatusDTO.NY)
+        assertThat(soknader.last().medlemskapVurdering).isNull()
+
+        val soknad = hentSoknad(
+            soknadId = hentSoknaderMetadata(fnr).first().id,
+            fnr = fnr
+        )
+
+        assertThat(soknad.sporsmal!!.map { it.tag }).isEqualTo(
+            listOf(
+                ANSVARSERKLARING,
+                TILBAKE_I_ARBEID,
+                FERIE_V2,
+                PERMISJON_V2,
+                medIndex(ARBEID_UNDERVEIS_100_PROSENT, 0),
+                ARBEID_UTENFOR_NORGE,
+                ANDRE_INNTEKTSKILDER_V2,
+                UTLAND_V2,
+                TIL_SLUTT
+            )
+        )
+    }
+
+    @Test
+    @Order(1)
+    fun `Oppretter søknad med status JA som ikke skal ha ARBEID_UTENFOR_NORGE`() {
+        val fnr = "31111111112"
+        medlemskapMockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                MedlemskapVurderingResponse(
+                    svar = MedlemskapVurderingSvarType.JA,
+                    sporsmal = emptyList()
+                ).serialisertTilString()
+            )
+        )
+
+        val soknader = sendSykmelding(
+            sykmeldingKafkaMessage(
+                arbeidssituasjon = Arbeidssituasjon.ARBEIDSTAKER,
+                fnr = fnr,
+                sykmeldingsperioder = heltSykmeldt(
+                    fom = LocalDate.of(2023, 1, 1),
+                    tom = LocalDate.of(2023, 1, 7)
+                )
+            )
+        )
+
+        assertThat(soknader).hasSize(1)
+        assertThat(soknader.last().type).isEqualTo(SoknadstypeDTO.ARBEIDSTAKERE)
+        assertThat(soknader.last().status).isEqualTo(SoknadsstatusDTO.NY)
+        assertThat(soknader.last().medlemskapVurdering).isEqualTo("JA")
+
+        val soknad = hentSoknad(
+            soknadId = hentSoknaderMetadata(fnr).first().id,
+            fnr = fnr
+        )
+
+        assertThat(soknad.sporsmal!!.map { it.tag }).isEqualTo(
+            listOf(
+                ANSVARSERKLARING,
+                TILBAKE_I_ARBEID,
+                FERIE_V2,
+                PERMISJON_V2,
+                medIndex(ARBEID_UNDERVEIS_100_PROSENT, 0),
+                ANDRE_INNTEKTSKILDER_V2,
+                UTLAND_V2,
+                TIL_SLUTT
+            )
+        )
+    }
+
+    @Test
+    @Order(1)
+    fun `Oppretter søknad med status NEI som ikke skal ha ARBEID_UTENFOR_NORGE`() {
+        val fnr = "31111111113"
+        medlemskapMockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                MedlemskapVurderingResponse(
+                    svar = MedlemskapVurderingSvarType.NEI,
+                    sporsmal = emptyList()
+                ).serialisertTilString()
+            )
+        )
+
+        val soknader = sendSykmelding(
+            sykmeldingKafkaMessage(
+                arbeidssituasjon = Arbeidssituasjon.ARBEIDSTAKER,
+                fnr = fnr,
+                sykmeldingsperioder = heltSykmeldt(
+                    fom = LocalDate.of(2023, 1, 1),
+                    tom = LocalDate.of(2023, 1, 7)
+                )
+            )
+        )
+
+        assertThat(soknader).hasSize(1)
+        assertThat(soknader.last().type).isEqualTo(SoknadstypeDTO.ARBEIDSTAKERE)
+        assertThat(soknader.last().status).isEqualTo(SoknadsstatusDTO.NY)
+        assertThat(soknader.last().medlemskapVurdering).isEqualTo("NEI")
+
+        val soknad = hentSoknad(
+            soknadId = hentSoknaderMetadata(fnr).first().id,
+            fnr = fnr
+        )
+
+        assertThat(soknad.sporsmal!!.map { it.tag }).isEqualTo(
+            listOf(
+                ANSVARSERKLARING,
+                TILBAKE_I_ARBEID,
+                FERIE_V2,
+                PERMISJON_V2,
+                medIndex(ARBEID_UNDERVEIS_100_PROSENT, 0),
+                ANDRE_INNTEKTSKILDER_V2,
+                UTLAND_V2,
+                TIL_SLUTT
+            )
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapSoknadstypeIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapSoknadstypeIntegrationTest.kt
@@ -1,0 +1,172 @@
+package no.nav.helse.flex.medlemskap
+
+import no.nav.helse.flex.BaseTestClass
+import no.nav.helse.flex.domain.Arbeidssituasjon
+import no.nav.helse.flex.hentProduserteRecords
+import no.nav.helse.flex.sendSykmelding
+import no.nav.helse.flex.sykepengesoknad.kafka.SoknadsstatusDTO
+import no.nav.helse.flex.sykepengesoknad.kafka.SoknadstypeDTO
+import no.nav.helse.flex.testdata.behandingsdager
+import no.nav.helse.flex.testdata.gradertReisetilskudd
+import no.nav.helse.flex.testdata.heltSykmeldt
+import no.nav.helse.flex.testdata.reisetilskudd
+import no.nav.helse.flex.testdata.sykmeldingKafkaMessage
+import no.nav.helse.flex.unleash.UNLEASH_CONTEXT_MEDLEMSKAP_SPORSMAL
+import no.nav.helse.flex.unleash.UNLEASH_CONTEXT_TIL_SLUTT_SPORSMAL
+import no.nav.helse.flex.util.serialisertTilString
+import okhttp3.mockwebserver.MockResponse
+import org.amshove.kluent.internal.assertEquals
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import java.time.LocalDate
+import java.util.concurrent.TimeUnit
+
+/**
+ * Tester at medlemskapspørsmål blir stilt på riktig søkandstype.
+ *
+ * LovMe lytter på og prosesserer Soknadstype.ARBEIDSTAKERE.
+ * Flex lager medlemskapsspørsmål på Arbeidssituasjon.ARBEIDSTAKER som inkluderer søknadstypene
+ * GRADERT_REISETILSKUDD og ARBEIDSTAKERE.
+ *
+ * Soknadstypene BEHANDLINGSDAGER og REISETILSKUDD tilhører også Arbeidssituasjon.ARBEIDSTAKER men disse blir
+ * filtert bort før det genereres medlemskapsspørsmål.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class MedlemskapSoknadstypeIntegrationTest : BaseTestClass() {
+
+    @BeforeAll
+    fun configureUnleash() {
+        fakeUnleash.resetAll()
+        fakeUnleash.enable(UNLEASH_CONTEXT_MEDLEMSKAP_SPORSMAL, UNLEASH_CONTEXT_TIL_SLUTT_SPORSMAL)
+    }
+
+    @AfterAll
+    fun hentAlleKafkaMeldinger() {
+        juridiskVurderingKafkaConsumer.hentProduserteRecords()
+        sykepengesoknadKafkaConsumer.hentProduserteRecords()
+    }
+
+    private val fom = LocalDate.of(2023, 1, 1)
+    private val tom = LocalDate.of(2023, 1, 7)
+
+    @Test
+    @Order(1)
+    fun `Soknadstype ARBEIDSTAKERE skal ha medlemskapspørsmål`() {
+        medlemskapMockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                MedlemskapVurderingResponse(
+                    svar = MedlemskapVurderingSvarType.UAVKLART,
+                    sporsmal = listOf(
+                        MedlemskapVurderingSporsmal.OPPHOLDSTILATELSE,
+                        MedlemskapVurderingSporsmal.ARBEID_UTENFOR_NORGE
+                    )
+                ).serialisertTilString()
+            )
+        )
+
+        val fnr = "31111111111"
+        val soknader = sendSykmelding(
+            sykmeldingKafkaMessage(
+                arbeidssituasjon = Arbeidssituasjon.ARBEIDSTAKER,
+                fnr = fnr,
+                sykmeldingsperioder = heltSykmeldt(
+                    fom = fom,
+                    tom = tom
+                )
+            )
+        )
+
+        assertEquals(fnr, medlemskapMockWebServer.takeRequest().headers["fnr"])
+
+        assertThat(soknader).hasSize(1)
+        assertThat(soknader.last().type).isEqualTo(SoknadstypeDTO.ARBEIDSTAKERE)
+        assertThat(soknader.last().status).isEqualTo(SoknadsstatusDTO.NY)
+        assertThat(soknader.last().medlemskapVurdering).isEqualTo("UAVKLART")
+    }
+
+    @Test
+    @Order(2)
+    fun `Soknadstype GRADERT_REISETILSKUDD skal ha medlemskapspørsmål`() {
+        medlemskapMockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                MedlemskapVurderingResponse(
+                    svar = MedlemskapVurderingSvarType.UAVKLART,
+                    sporsmal = listOf(
+                        MedlemskapVurderingSporsmal.OPPHOLDSTILATELSE,
+                        MedlemskapVurderingSporsmal.ARBEID_UTENFOR_NORGE
+                    )
+                ).serialisertTilString()
+            )
+        )
+
+        val fnr = "31111111112"
+        val soknader = sendSykmelding(
+            sykmeldingKafkaMessage(
+                arbeidssituasjon = Arbeidssituasjon.ARBEIDSTAKER,
+                fnr = fnr,
+                sykmeldingsperioder = gradertReisetilskudd(
+                    fom = fom,
+                    tom = tom
+                )
+            )
+        )
+
+        assertEquals(fnr, medlemskapMockWebServer.takeRequest().headers["fnr"])
+
+        assertThat(soknader).hasSize(1)
+        assertThat(soknader.last().type).isEqualTo(SoknadstypeDTO.GRADERT_REISETILSKUDD)
+        assertThat(soknader.last().status).isEqualTo(SoknadsstatusDTO.NY)
+        assertThat(soknader.last().medlemskapVurdering).isEqualTo("UAVKLART")
+    }
+
+    @Test
+    @Order(3)
+    fun `Soknadstype BEHANDLINGSDAGER skal ikke ha medlemskapspørsmål`() {
+        val fnr = "31111111113"
+        val soknader = sendSykmelding(
+            sykmeldingKafkaMessage(
+                arbeidssituasjon = Arbeidssituasjon.ARBEIDSTAKER,
+                fnr = fnr,
+                sykmeldingsperioder = behandingsdager(
+                    fom = fom,
+                    tom = tom
+                )
+            )
+        )
+
+        assertThat(medlemskapMockWebServer.takeRequest(500, TimeUnit.MILLISECONDS)).isNull()
+
+        assertThat(soknader).hasSize(1)
+        assertThat(soknader.last().type).isEqualTo(SoknadstypeDTO.BEHANDLINGSDAGER)
+        assertThat(soknader.last().status).isEqualTo(SoknadsstatusDTO.NY)
+        assertThat(soknader.last().medlemskapVurdering).isNull()
+    }
+
+    @Test
+    @Order(4)
+    fun `Soknadstype REISETILSKUDD skal ikke ha medlemskapspørsmål`() {
+        val fnr = "31111111114"
+        val soknader = sendSykmelding(
+            sykmeldingKafkaMessage(
+                arbeidssituasjon = Arbeidssituasjon.ARBEIDSTAKER,
+                fnr = fnr,
+                sykmeldingsperioder = reisetilskudd(
+                    fom = fom,
+                    tom = tom
+                )
+            )
+        )
+
+        assertThat(medlemskapMockWebServer.takeRequest(500, TimeUnit.MILLISECONDS)).isNull()
+
+        assertThat(soknader).hasSize(1)
+        assertThat(soknader.last().type).isEqualTo(SoknadstypeDTO.REISETILSKUDD)
+        assertThat(soknader.last().status).isEqualTo(SoknadsstatusDTO.NY)
+        assertThat(soknader.last().medlemskapVurdering).isNull()
+    }
+}

--- a/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapSoknadstypeIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapSoknadstypeIntegrationTest.kt
@@ -15,7 +15,6 @@ import no.nav.helse.flex.unleash.UNLEASH_CONTEXT_MEDLEMSKAP_SPORSMAL
 import no.nav.helse.flex.unleash.UNLEASH_CONTEXT_TIL_SLUTT_SPORSMAL
 import no.nav.helse.flex.util.serialisertTilString
 import okhttp3.mockwebserver.MockResponse
-import org.amshove.kluent.internal.assertEquals
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -24,7 +23,6 @@ import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import java.time.LocalDate
-import java.util.concurrent.TimeUnit
 
 /**
  * Tester at medlemskapspørsmål blir stilt på riktig søkandstype.
@@ -81,8 +79,6 @@ class MedlemskapSoknadstypeIntegrationTest : BaseTestClass() {
             )
         )
 
-        assertEquals(fnr, medlemskapMockWebServer.takeRequest().headers["fnr"])
-
         assertThat(soknader).hasSize(1)
         assertThat(soknader.last().type).isEqualTo(SoknadstypeDTO.ARBEIDSTAKERE)
         assertThat(soknader.last().status).isEqualTo(SoknadsstatusDTO.NY)
@@ -116,8 +112,6 @@ class MedlemskapSoknadstypeIntegrationTest : BaseTestClass() {
             )
         )
 
-        assertEquals(fnr, medlemskapMockWebServer.takeRequest().headers["fnr"])
-
         assertThat(soknader).hasSize(1)
         assertThat(soknader.last().type).isEqualTo(SoknadstypeDTO.GRADERT_REISETILSKUDD)
         assertThat(soknader.last().status).isEqualTo(SoknadsstatusDTO.NY)
@@ -139,8 +133,6 @@ class MedlemskapSoknadstypeIntegrationTest : BaseTestClass() {
             )
         )
 
-        assertThat(medlemskapMockWebServer.takeRequest(500, TimeUnit.MILLISECONDS)).isNull()
-
         assertThat(soknader).hasSize(1)
         assertThat(soknader.last().type).isEqualTo(SoknadstypeDTO.BEHANDLINGSDAGER)
         assertThat(soknader.last().status).isEqualTo(SoknadsstatusDTO.NY)
@@ -161,8 +153,6 @@ class MedlemskapSoknadstypeIntegrationTest : BaseTestClass() {
                 )
             )
         )
-
-        assertThat(medlemskapMockWebServer.takeRequest(500, TimeUnit.MILLISECONDS)).isNull()
 
         assertThat(soknader).hasSize(1)
         assertThat(soknader.last().type).isEqualTo(SoknadstypeDTO.REISETILSKUDD)

--- a/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapSporsmalIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapSporsmalIntegrationTest.kt
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.TestMethodOrder
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
-import java.util.concurrent.TimeUnit
 
 /**
  * Tester at spørsmål om medlemskap blir opprettet og besvart som forventet, inkludert at
@@ -55,11 +54,6 @@ class MedlemskapSporsmalIntegrationTest : BaseTestClass() {
     @AfterAll
     fun hentAlleKafkaMeldinger() {
         juridiskVurderingKafkaConsumer.hentProduserteRecords()
-    }
-
-    @AfterAll
-    fun sjekkAtAlleMockWebServerRequestsErKonsumert() {
-        assertThat(medlemskapMockWebServer.takeRequest(100, TimeUnit.MILLISECONDS)).isNull()
     }
 
     private val fnr = "31111111111"
@@ -93,10 +87,6 @@ class MedlemskapSporsmalIntegrationTest : BaseTestClass() {
                 )
             )
         )
-
-        medlemskapMockWebServer.takeRequest().let {
-            it.headers["fnr"] `should be equal to` fnr
-        }
 
         assertThat(soknader).hasSize(1)
         assertThat(soknader.last().type).isEqualTo(SoknadstypeDTO.ARBEIDSTAKERE)

--- a/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapSyketilfelleIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapSyketilfelleIntegrationTest.kt
@@ -20,7 +20,6 @@ import no.nav.helse.flex.util.flatten
 import no.nav.helse.flex.util.serialisertTilString
 import no.nav.syfo.model.sykmeldingstatus.ArbeidsgiverStatusDTO
 import okhttp3.mockwebserver.MockResponse
-import org.amshove.kluent.`should be equal to`
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
-import java.util.concurrent.TimeUnit
 
 /**
  * Tester forskjellige scenario relatert til at medlemskapspørsmål kun skal stilles i den første søknaden
@@ -59,11 +57,6 @@ class MedlemskapSyketilfelleIntegrationTest : BaseTestClass() {
     @AfterAll
     fun hentAlleKafkaMeldinger() {
         juridiskVurderingKafkaConsumer.hentProduserteRecords()
-    }
-
-    @AfterAll
-    fun sjekkAtAlleMockWebServerRequestsErKonsumert() {
-        assertThat(medlemskapMockWebServer.takeRequest(100, TimeUnit.MILLISECONDS)).isNull()
     }
 
     private val fnr = "31111111111"
@@ -98,10 +91,6 @@ class MedlemskapSyketilfelleIntegrationTest : BaseTestClass() {
                 )
             )
         )
-
-        medlemskapMockWebServer.takeRequest().let {
-            it.headers["fnr"] `should be equal to` fnr
-        }
 
         assertThat(soknader1).hasSize(1)
         assertThat(soknader1.last().medlemskapVurdering).isEqualTo("UAVKLART")
@@ -145,12 +134,6 @@ class MedlemskapSyketilfelleIntegrationTest : BaseTestClass() {
                 )
             )
         )
-
-        repeat(2) {
-            medlemskapMockWebServer.takeRequest().let {
-                it.headers["fnr"] `should be equal to` fnr
-            }
-        }
 
         assertThat(soknader1).hasSize(1)
         assertThat(soknader1.last().medlemskapVurdering).isEqualTo("UAVKLART")
@@ -199,12 +182,6 @@ class MedlemskapSyketilfelleIntegrationTest : BaseTestClass() {
             )
         )
 
-        repeat(2) {
-            medlemskapMockWebServer.takeRequest().let {
-                it.headers["fnr"] `should be equal to` fnr
-            }
-        }
-
         assertThat(soknader1).hasSize(1)
         assertThat(soknader1.last().medlemskapVurdering).isEqualTo("UAVKLART")
         assertThat(soknader1.last().forstegangssoknad).isTrue()
@@ -242,10 +219,6 @@ class MedlemskapSyketilfelleIntegrationTest : BaseTestClass() {
                 )
             )
         )
-
-        medlemskapMockWebServer.takeRequest().let {
-            it.headers["fnr"] `should be equal to` fnr
-        }
 
         assertThat(soknader).hasSize(2)
         assertThat(soknader.first().medlemskapVurdering).isEqualTo("UAVKLART")
@@ -287,10 +260,6 @@ class MedlemskapSyketilfelleIntegrationTest : BaseTestClass() {
             )
         )
 
-        medlemskapMockWebServer.takeRequest().let {
-            it.headers["fnr"] `should be equal to` fnr
-        }
-
         val lagretForstegangssoknad = hentSoknad(fnr = fnr, soknadId = soknader1.first().id)
         assertThat(lagretForstegangssoknad.sporsmal!!.find { it.tag == MEDLEMSKAP_OPPHOLDSTILLATELSE }).isNull()
 
@@ -331,12 +300,6 @@ class MedlemskapSyketilfelleIntegrationTest : BaseTestClass() {
                 )
             )
         )
-
-        repeat(2) {
-            medlemskapMockWebServer.takeRequest().let {
-                it.headers["fnr"] `should be equal to` fnr
-            }
-        }
 
         assertThat(soknader1).hasSize(1)
         assertThat(soknader1.last().medlemskapVurdering).isEqualTo("UAVKLART")

--- a/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapToggleIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapToggleIntegrationTest.kt
@@ -14,6 +14,7 @@ import no.nav.helse.flex.unleash.UNLEASH_CONTEXT_MEDLEMSKAP_SPORSMAL
 import no.nav.helse.flex.unleash.UNLEASH_CONTEXT_TIL_SLUTT_SPORSMAL
 import no.nav.helse.flex.util.serialisertTilString
 import okhttp3.mockwebserver.MockResponse
+import org.amshove.kluent.`should be equal to`
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import java.time.LocalDate
+import java.util.concurrent.TimeUnit
 
 /**
  * Tester at toggle for medlemskapspørsmål fungerer som forventet. Dvs. at det ikke stilles spørsmål om arbeid utenfor
@@ -61,6 +63,11 @@ class MedlemskapToggleIntegrationTest : BaseTestClass() {
         juridiskVurderingKafkaConsumer.hentProduserteRecords()
     }
 
+    @AfterAll
+    fun sjekkAtAlleMockWebServerRequestsErKonsumert() {
+        assertThat(medlemskapMockWebServer.takeRequest(100, TimeUnit.MILLISECONDS)).isNull()
+    }
+
     private val fnr = "31111111111"
 
     @Test
@@ -76,6 +83,10 @@ class MedlemskapToggleIntegrationTest : BaseTestClass() {
             soknadId = hentSoknaderMetadata(fnr).first().id,
             fnr = fnr
         )
+
+        medlemskapMockWebServer.takeRequest().let {
+            it.headers["fnr"] `should be equal to` fnr
+        }
 
         assertThat(lagretSoknad.sporsmal!!.map { it.tag }).isEqualTo(
             listOf(
@@ -106,6 +117,10 @@ class MedlemskapToggleIntegrationTest : BaseTestClass() {
             soknadId = hentSoknaderMetadata(fnr).first().id,
             fnr = fnr
         )
+
+        medlemskapMockWebServer.takeRequest().let {
+            it.headers["fnr"] `should be equal to` fnr
+        }
 
         assertThat(lagretSoknad.sporsmal!!.map { it.tag }).isEqualTo(
             listOf(

--- a/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapToggleIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapToggleIntegrationTest.kt
@@ -14,7 +14,6 @@ import no.nav.helse.flex.unleash.UNLEASH_CONTEXT_MEDLEMSKAP_SPORSMAL
 import no.nav.helse.flex.unleash.UNLEASH_CONTEXT_TIL_SLUTT_SPORSMAL
 import no.nav.helse.flex.util.serialisertTilString
 import okhttp3.mockwebserver.MockResponse
-import org.amshove.kluent.`should be equal to`
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
@@ -23,7 +22,6 @@ import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import java.time.LocalDate
-import java.util.concurrent.TimeUnit
 
 /**
  * Tester at toggle for medlemskapspørsmål fungerer som forventet. Dvs. at det ikke stilles spørsmål om arbeid utenfor
@@ -63,11 +61,6 @@ class MedlemskapToggleIntegrationTest : BaseTestClass() {
         juridiskVurderingKafkaConsumer.hentProduserteRecords()
     }
 
-    @AfterAll
-    fun sjekkAtAlleMockWebServerRequestsErKonsumert() {
-        assertThat(medlemskapMockWebServer.takeRequest(100, TimeUnit.MILLISECONDS)).isNull()
-    }
-
     private val fnr = "31111111111"
 
     @Test
@@ -83,10 +76,6 @@ class MedlemskapToggleIntegrationTest : BaseTestClass() {
             soknadId = hentSoknaderMetadata(fnr).first().id,
             fnr = fnr
         )
-
-        medlemskapMockWebServer.takeRequest().let {
-            it.headers["fnr"] `should be equal to` fnr
-        }
 
         assertThat(lagretSoknad.sporsmal!!.map { it.tag }).isEqualTo(
             listOf(
@@ -117,10 +106,6 @@ class MedlemskapToggleIntegrationTest : BaseTestClass() {
             soknadId = hentSoknaderMetadata(fnr).first().id,
             fnr = fnr
         )
-
-        medlemskapMockWebServer.takeRequest().let {
-            it.headers["fnr"] `should be equal to` fnr
-        }
 
         assertThat(lagretSoknad.sporsmal!!.map { it.tag }).isEqualTo(
             listOf(

--- a/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapUavklartIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapUavklartIntegrationTest.kt
@@ -22,7 +22,6 @@ import no.nav.helse.flex.unleash.UNLEASH_CONTEXT_TIL_SLUTT_SPORSMAL
 import no.nav.helse.flex.util.serialisertTilString
 import no.nav.helse.flex.ventPåRecords
 import okhttp3.mockwebserver.MockResponse
-import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldHaveSize
 import org.assertj.core.api.Assertions.assertThat
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import java.time.LocalDate
-import java.util.concurrent.TimeUnit
 
 /**
  * Tester som verifiserer at flagget "medlemskapVurdering" ikke er statt på søknader som sendes på Kafka
@@ -51,11 +49,6 @@ class MedlemskapUavklartIntegrationTest : BaseTestClass() {
     @AfterAll
     fun hentAlleKafkaMeldinger() {
         juridiskVurderingKafkaConsumer.hentProduserteRecords()
-    }
-
-    @AfterAll
-    fun sjekkAtAlleMockWebServerRequestsErKonsumert() {
-        assertThat(medlemskapMockWebServer.takeRequest(100, TimeUnit.MILLISECONDS)).isNull()
     }
 
     @Test
@@ -91,10 +84,6 @@ class MedlemskapUavklartIntegrationTest : BaseTestClass() {
             soknadId = hentSoknaderMetadata(fnr).first().id,
             fnr = fnr
         )
-
-        medlemskapMockWebServer.takeRequest().let {
-            it.headers["fnr"] `should be equal to` fnr
-        }
 
         assertThat(soknad.sporsmal!!.map { it.tag }).isEqualTo(
             listOf(

--- a/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapVurderingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapVurderingIntegrationTest.kt
@@ -9,13 +9,15 @@ import org.amshove.kluent.`should not be`
 import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldHaveSize
 import org.amshove.kluent.shouldStartWith
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
 import java.util.*
+import java.util.concurrent.TimeUnit
 
 /**
  * Tester hvordan koden som integrerer med LovMe for å hente spørsmål om medlemskap
@@ -30,16 +32,14 @@ class MedlemskapVurderingIntegrationTest : BaseTestClass() {
     @Autowired
     private lateinit var medlemskapVurderingRepository: MedlemskapVurderingRepository
 
-    @BeforeAll
-    fun `Tøm requests til medlemskapVurdering`() {
-        repeat(medlemskapMockWebServer.requestCount) {
-            medlemskapMockWebServer.takeRequest()
-        }
-    }
-
     @AfterEach
     fun slettFraDatabase() {
         medlemskapVurderingRepository.deleteAll()
+    }
+
+    @AfterAll
+    fun sjekkAtAlleMockWebServerRequestsErKonsumert() {
+        Assertions.assertThat(medlemskapMockWebServer.takeRequest(100, TimeUnit.MILLISECONDS)).isNull()
     }
 
     private val sykepengesoknadId = UUID.randomUUID().toString()
@@ -81,11 +81,12 @@ class MedlemskapVurderingIntegrationTest : BaseTestClass() {
             MedlemskapVurderingSporsmal.OPPHOLD_UTENFOR_NORGE
         )
 
-        val takeRequest = medlemskapMockWebServer.takeRequest()
-        takeRequest.headers["fnr"] `should be equal to` fnr
-        takeRequest.headers["Nav-Call-Id"] `should be equal to` request.sykepengesoknadId
-        takeRequest.headers["Authorization"]!!.shouldStartWith("Bearer ey")
-        takeRequest.path `should be equal to` "/$MEDLEMSKAP_VURDERING_PATH?fom=$fom&tom=$tom"
+        medlemskapMockWebServer.takeRequest().let {
+            it.headers["fnr"] `should be equal to` fnr
+            it.headers["Nav-Call-Id"] `should be equal to` request.sykepengesoknadId
+            it.headers["Authorization"]!!.shouldStartWith("Bearer ey")
+            it.path `should be equal to` "/$MEDLEMSKAP_VURDERING_PATH?fom=$fom&tom=$tom"
+        }
 
         val dbRecords = medlemskapVurderingRepository.findAll() shouldHaveSize 1
         dbRecords.first().sporsmal `should not be` null
@@ -108,8 +109,9 @@ class MedlemskapVurderingIntegrationTest : BaseTestClass() {
         response.svar `should be equal to` MedlemskapVurderingSvarType.UAVKLART
         response.sporsmal shouldHaveSize 0
 
-        val takeRequest = medlemskapMockWebServer.takeRequest()
-        takeRequest.headers["fnr"] `should be equal to` fnr
+        medlemskapMockWebServer.takeRequest().let {
+            it.headers["fnr"] `should be equal to` fnr
+        }
 
         medlemskapVurderingRepository.findAll() shouldHaveSize 1
 
@@ -134,8 +136,9 @@ class MedlemskapVurderingIntegrationTest : BaseTestClass() {
         response.svar `should be equal to` MedlemskapVurderingSvarType.JA
         response.sporsmal shouldHaveSize 0
 
-        val takeRequest = medlemskapMockWebServer.takeRequest()
-        takeRequest.headers["fnr"] `should be equal to` fnr
+        medlemskapMockWebServer.takeRequest().let {
+            it.headers["fnr"] `should be equal to` fnr
+        }
 
         // Vi lagrer ikke tom liste med spørsmål.
         val dbRecords = medlemskapVurderingRepository.findAll() shouldHaveSize 1
@@ -159,8 +162,9 @@ class MedlemskapVurderingIntegrationTest : BaseTestClass() {
         response.svar `should be equal to` MedlemskapVurderingSvarType.NEI
         response.sporsmal shouldHaveSize 0
 
-        val takeRequest = medlemskapMockWebServer.takeRequest()
-        takeRequest.headers["fnr"] `should be equal to` fnr
+        medlemskapMockWebServer.takeRequest().let {
+            it.headers["fnr"] `should be equal to` fnr
+        }
 
         medlemskapVurderingRepository.findAll() shouldHaveSize 1
 
@@ -186,8 +190,9 @@ class MedlemskapVurderingIntegrationTest : BaseTestClass() {
         exception.message?.shouldStartWith("MedlemskapVurdering med Nav-Call-Id:")
         exception.cause!!.message?.shouldStartWith("500 Server Error")
 
-        val takeRequest = medlemskapMockWebServer.takeRequest()
-        takeRequest.headers["fnr"] `should be equal to` fnr
+        medlemskapMockWebServer.takeRequest().let {
+            it.headers["fnr"] `should be equal to` fnr
+        }
 
         medlemskapVurderingRepository.findAll() shouldHaveSize 0
     }
@@ -209,8 +214,9 @@ class MedlemskapVurderingIntegrationTest : BaseTestClass() {
         exception.message?.shouldStartWith("MedlemskapVurdering med Nav-Call-Id:")
         exception.cause!!.message?.shouldStartWith("400 Client Error")
 
-        val takeRequest = medlemskapMockWebServer.takeRequest()
-        takeRequest.headers["fnr"] `should be equal to` fnr
+        medlemskapMockWebServer.takeRequest().let {
+            it.headers["fnr"] `should be equal to` fnr
+        }
 
         medlemskapVurderingRepository.findAll() shouldHaveSize 0
     }
@@ -239,8 +245,9 @@ class MedlemskapVurderingIntegrationTest : BaseTestClass() {
         exception.message?.shouldStartWith("MedlemskapVurdering med Nav-Call-Id:")
         exception.message?.shouldContain("returnerte spørsmål selv om svar var svar.JA.")
 
-        val takeRequest = medlemskapMockWebServer.takeRequest()
-        takeRequest.headers["fnr"] `should be equal to` fnr
+        medlemskapMockWebServer.takeRequest().let {
+            it.headers["fnr"] `should be equal to` fnr
+        }
 
         medlemskapVurderingRepository.findAll() shouldHaveSize 1
 
@@ -273,8 +280,9 @@ class MedlemskapVurderingIntegrationTest : BaseTestClass() {
         exception.message?.shouldStartWith("MedlemskapVurdering med Nav-Call-Id:")
         exception.message?.shouldContain("returnerte spørsmål selv om svar var svar.NEI.")
 
-        val takeRequest = medlemskapMockWebServer.takeRequest()
-        takeRequest.headers["fnr"] `should be equal to` fnr
+        medlemskapMockWebServer.takeRequest().let {
+            it.headers["fnr"] `should be equal to` fnr
+        }
 
         // Verdier blir lagret før vi validerer responsen sånn at vi kan feilsøke.
         val dbRecords = medlemskapVurderingRepository.findAll() shouldHaveSize 1

--- a/src/test/kotlin/no/nav/helse/flex/testdata/SykmeldingGenerator.kt
+++ b/src/test/kotlin/no/nav/helse/flex/testdata/SykmeldingGenerator.kt
@@ -214,6 +214,24 @@ fun reisetilskudd(
     )
 }
 
+fun gradertReisetilskudd(
+    fom: LocalDate = LocalDate.of(2020, 2, 1),
+    tom: LocalDate = LocalDate.of(2020, 2, 15)
+): List<SykmeldingsperiodeAGDTO> {
+    return listOf(
+        SykmeldingsperiodeAGDTO(
+            fom = fom,
+            tom = tom,
+            type = PeriodetypeDTO.GRADERT,
+            reisetilskudd = false,
+            aktivitetIkkeMulig = null,
+            behandlingsdager = null,
+            gradert = GradertDTO(50, true),
+            innspillTilArbeidsgiver = null
+        )
+    )
+}
+
 fun behandingsdager(
     fom: LocalDate = LocalDate.of(2018, 1, 1),
     tom: LocalDate = LocalDate.of(2018, 1, 10),


### PR DESCRIPTION
- Tillater ast feltet SykepengesoknadKafkaDto.medlemskapVurdering blir populert for Soknadstype.GRADERT_REISETILSKUDD.
- Legger til tester som verifiserer at Soknadstype.GRADERT_REISETILSKUDD får medlemskapspørsmål og at  SykepengesoknadKafkaDto.medlemskapVurdering blir populert.
- Splittet test som testet to urelaterte tema til to tester.
- Lag til test-util for å sende søknader som ender som Gradert Reisetilskudd.

Det er verd å merke seg at all kode som verifiserer requests til medlemskapMockWebServer med "take()" er fjernet i påvente av ett oppsett av MockWebServer som ikke fører til tett avhengighet mellom integrasjonstestene på grunn av at samme instans gjenbrukes.