### PR TITLE
Kalkuler inntektsopplysninger for næringsdrivende

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/controller/domain/sykepengesoknad/RSSykepengesoknad.kt
+++ b/src/main/kotlin/no/nav/helse/flex/controller/domain/sykepengesoknad/RSSykepengesoknad.kt
@@ -1,5 +1,6 @@
 package no.nav.helse.flex.controller.domain.sykepengesoknad
 
+import no.nav.helse.flex.inntektsopplysninger.InntektsopplysningerDokumentType
 import no.nav.helse.flex.soknadsopprettelse.ArbeidsforholdFraInntektskomponenten
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -29,6 +30,9 @@ data class RSSykepengesoknad(
     val utenlandskSykmelding: Boolean,
     val klippet: Boolean,
     val inntektskilderDataFraInntektskomponenten: List<ArbeidsforholdFraInntektskomponenten>?,
+    val inntektsopplysningerNyKvittering: Boolean? = null,
+    val inntektsopplysningerInnsendingId: String? = null,
+    val inntektsopplysningerInnsendingDokumenter: List<InntektsopplysningerDokumentType>? = null
     val korrigeringsfristUtlopt: Boolean?,
     val forstegangssoknad: Boolean?
 ) {

--- a/src/main/kotlin/no/nav/helse/flex/controller/domain/sykepengesoknad/RSSykepengesoknad.kt
+++ b/src/main/kotlin/no/nav/helse/flex/controller/domain/sykepengesoknad/RSSykepengesoknad.kt
@@ -32,7 +32,7 @@ data class RSSykepengesoknad(
     val inntektskilderDataFraInntektskomponenten: List<ArbeidsforholdFraInntektskomponenten>?,
     val inntektsopplysningerNyKvittering: Boolean? = null,
     val inntektsopplysningerInnsendingId: String? = null,
-    val inntektsopplysningerInnsendingDokumenter: List<InntektsopplysningerDokumentType>? = null
+    val inntektsopplysningerInnsendingDokumenter: List<InntektsopplysningerDokumentType>? = null,
     val korrigeringsfristUtlopt: Boolean?,
     val forstegangssoknad: Boolean?
 ) {

--- a/src/main/kotlin/no/nav/helse/flex/controller/mapper/SykepengesoknadToRS.kt
+++ b/src/main/kotlin/no/nav/helse/flex/controller/mapper/SykepengesoknadToRS.kt
@@ -107,6 +107,9 @@ fun Sykepengesoknad.tilRSSykepengesoknad() = RSSykepengesoknad(
     klippet = this.klippet,
     inntektskilderDataFraInntektskomponenten = this.inntektskilderDataFraInntektskomponenten,
     korrigeringsfristUtlopt = this.korrigeringsfristUtlopt,
+    inntektsopplysningerNyKvittering = this.inntektsopplysningerNyKvittering,
+    inntektsopplysningerInnsendingId = this.inntektsopplysningerInnsendingId,
+    inntektsopplysningerInnsendingDokumenter = this.inntektsopplysningerInnsendingDokumenter,
     forstegangssoknad = this.forstegangssoknad
 )
 

--- a/src/main/kotlin/no/nav/helse/flex/domain/Sykepengesoknad.kt
+++ b/src/main/kotlin/no/nav/helse/flex/domain/Sykepengesoknad.kt
@@ -1,5 +1,6 @@
 package no.nav.helse.flex.domain
 
+import no.nav.helse.flex.inntektsopplysninger.InntektsopplysningerDokumentType
 import no.nav.helse.flex.soknadsopprettelse.ArbeidsforholdFraInntektskomponenten
 import java.io.Serializable
 import java.time.Instant
@@ -42,7 +43,10 @@ data class Sykepengesoknad(
     val inntektskilderDataFraInntektskomponenten: List<ArbeidsforholdFraInntektskomponenten>? = null,
     val korrigeringsfristUtlopt: Boolean? = null,
     val forstegangssoknad: Boolean?,
-    val tidligereArbeidsgiverOrgnummer: String? = null
+    val tidligereArbeidsgiverOrgnummer: String? = null,
+    val inntektsopplysningerNyKvittering: Boolean? = null,
+    val inntektsopplysningerInnsendingId: String? = null,
+    val inntektsopplysningerInnsendingDokumenter: List<InntektsopplysningerDokumentType>? = null
 ) : Serializable {
 
     fun alleSporsmalOgUndersporsmal(): List<Sporsmal> {

--- a/src/main/kotlin/no/nav/helse/flex/inntektsopplysninger/HvilkeDokumenter.kt
+++ b/src/main/kotlin/no/nav/helse/flex/inntektsopplysninger/HvilkeDokumenter.kt
@@ -1,0 +1,39 @@
+package no.nav.helse.flex.inntektsopplysninger
+
+import no.nav.helse.flex.inntektsopplysninger.DokumentTyper.NARINGSSPESIFIKASJON
+import no.nav.helse.flex.inntektsopplysninger.DokumentTyper.NARINGSSPESIFIKASJON_OPTIONAL
+import no.nav.helse.flex.inntektsopplysninger.DokumentTyper.REGNSKAP_FORELOPIG
+import no.nav.helse.flex.inntektsopplysninger.DokumentTyper.REGNSKAP_FORRIGE_AAR
+import no.nav.helse.flex.inntektsopplysninger.DokumentTyper.SKATTEMELDING
+import no.nav.helse.flex.inntektsopplysninger.DokumentTyper.SKATTEMELDING_OPTIONAL
+import java.time.LocalDate
+
+
+enum class DokumentTyper {
+    SKATTEMELDING,
+    SKATTEMELDING_OPTIONAL,
+    NARINGSSPESIFIKASJON,
+    NARINGSSPESIFIKASJON_OPTIONAL,
+    REGNSKAP_FORRIGE_AAR,
+    REGNSKAP_FORELOPIG
+}
+
+internal fun dokumenterSomkalSendes(dagensDato: LocalDate): List<DokumentTyper> {
+    val sisteTertialStart = LocalDate.of(dagensDato.year, 9, 1)
+    val fristSkattemelding = LocalDate.of(dagensDato.year, 5, 31)
+
+    return when {
+        dagensDato.isBefore(fristSkattemelding) -> listOf(
+            REGNSKAP_FORRIGE_AAR,
+            SKATTEMELDING_OPTIONAL,
+            NARINGSSPESIFIKASJON_OPTIONAL
+        )
+
+        dagensDato.isAfter(fristSkattemelding) && dagensDato.isBefore(sisteTertialStart) -> listOf(
+            SKATTEMELDING,
+            NARINGSSPESIFIKASJON
+        )
+
+        else -> listOf(SKATTEMELDING, NARINGSSPESIFIKASJON, REGNSKAP_FORELOPIG)
+    }
+}

--- a/src/main/kotlin/no/nav/helse/flex/inntektsopplysninger/InntektsopplysningForNaringsdrivende.kt
+++ b/src/main/kotlin/no/nav/helse/flex/inntektsopplysninger/InntektsopplysningForNaringsdrivende.kt
@@ -1,0 +1,74 @@
+package no.nav.helse.flex.inntektsopplysninger
+
+import no.nav.helse.flex.domain.Arbeidssituasjon
+import no.nav.helse.flex.domain.Soknadstype
+import no.nav.helse.flex.domain.Sykepengesoknad
+import no.nav.helse.flex.repository.SykepengesoknadRepository
+import no.nav.helse.flex.soknadsopprettelse.INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET
+import no.nav.helse.flex.soknadsopprettelse.INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET_JA
+import no.nav.helse.flex.soknadsopprettelse.INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET_NEI
+import no.nav.helse.flex.soknadsopprettelse.INNTEKTSOPPLYSNINGER_VARIG_ENDRING_25_PROSENT
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+@Service
+class InntektsopplysningForNaringsdrivende(private val sykepengesoknadRepository: SykepengesoknadRepository) {
+
+    fun Sykepengesoknad.skalHaInntektsmeldingDokumenter(): Boolean {
+        getSporsmalMedTagOrNull(INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET_JA)?.let {
+            if (it.forsteSvar == "CHECKED") {
+                return true
+            }
+        }
+
+        getSporsmalMedTagOrNull(INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET_NEI)?.let { sporsmal1 ->
+            if (sporsmal1.forsteSvar == "CHECKED") {
+                getSporsmalMedTagOrNull(INNTEKTSOPPLYSNINGER_VARIG_ENDRING_25_PROSENT)?.let {
+                    if (it.forsteSvar == "JA") {
+                        return true
+                    }
+                }
+            }
+        }
+        return false
+    }
+
+    fun lagreInnsendingsopplysninger(soknad: Sykepengesoknad) {
+        if (soknad.arbeidssituasjon != Arbeidssituasjon.NAERINGSDRIVENDE) {
+            return
+        }
+
+        if (!listOf(
+                Soknadstype.GRADERT_REISETILSKUDD,
+                Soknadstype.SELVSTENDIGE_OG_FRILANSERE
+            ).contains(soknad.soknadstype)
+        ) {
+            return
+        }
+
+        if (soknad.forstegangssoknad != true) {
+            return
+        }
+
+        val erNyKvittering = soknad.getSporsmalMedTagOrNull(INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET) != null
+
+        sykepengesoknadRepository.findBySykepengesoknadUuid(soknad.id)?.let { sykepengeSoknad ->
+            val oppdatertSykepengeSoknad = if (soknad.skalHaInntektsmeldingDokumenter()) {
+                val dokumenter = dokumenterSomSkalSendes(LocalDate.now()).joinToString(",")
+                val innsendingsId = "TODO"
+
+                sykepengeSoknad.copy(
+                    inntektsopplysningerNyKvittering = erNyKvittering,
+                    inntektsopplysningerInnsendingId = innsendingsId,
+                    inntektsopplysningerInnsendingDokumenter = dokumenter
+                )
+            } else {
+                sykepengeSoknad.copy(
+                    inntektsopplysningerNyKvittering = erNyKvittering
+                )
+            }
+
+            sykepengesoknadRepository.save(oppdatertSykepengeSoknad)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/helse/flex/inntektsopplysninger/InntektsopplysningerDokumentType.kt
+++ b/src/main/kotlin/no/nav/helse/flex/inntektsopplysninger/InntektsopplysningerDokumentType.kt
@@ -1,15 +1,14 @@
 package no.nav.helse.flex.inntektsopplysninger
 
-import no.nav.helse.flex.inntektsopplysninger.DokumentTyper.NARINGSSPESIFIKASJON
-import no.nav.helse.flex.inntektsopplysninger.DokumentTyper.NARINGSSPESIFIKASJON_OPTIONAL
-import no.nav.helse.flex.inntektsopplysninger.DokumentTyper.REGNSKAP_FORELOPIG
-import no.nav.helse.flex.inntektsopplysninger.DokumentTyper.REGNSKAP_FORRIGE_AAR
-import no.nav.helse.flex.inntektsopplysninger.DokumentTyper.SKATTEMELDING
-import no.nav.helse.flex.inntektsopplysninger.DokumentTyper.SKATTEMELDING_OPTIONAL
+import no.nav.helse.flex.inntektsopplysninger.InntektsopplysningerDokumentType.NARINGSSPESIFIKASJON
+import no.nav.helse.flex.inntektsopplysninger.InntektsopplysningerDokumentType.NARINGSSPESIFIKASJON_OPTIONAL
+import no.nav.helse.flex.inntektsopplysninger.InntektsopplysningerDokumentType.REGNSKAP_FORELOPIG
+import no.nav.helse.flex.inntektsopplysninger.InntektsopplysningerDokumentType.REGNSKAP_FORRIGE_AAR
+import no.nav.helse.flex.inntektsopplysninger.InntektsopplysningerDokumentType.SKATTEMELDING
+import no.nav.helse.flex.inntektsopplysninger.InntektsopplysningerDokumentType.SKATTEMELDING_OPTIONAL
 import java.time.LocalDate
 
-
-enum class DokumentTyper {
+enum class InntektsopplysningerDokumentType {
     SKATTEMELDING,
     SKATTEMELDING_OPTIONAL,
     NARINGSSPESIFIKASJON,
@@ -18,7 +17,7 @@ enum class DokumentTyper {
     REGNSKAP_FORELOPIG
 }
 
-internal fun dokumenterSomkalSendes(dagensDato: LocalDate): List<DokumentTyper> {
+fun dokumenterSomSkalSendes(dagensDato: LocalDate): List<InntektsopplysningerDokumentType> {
     val sisteTertialStart = LocalDate.of(dagensDato.year, 9, 1)
     val fristSkattemelding = LocalDate.of(dagensDato.year, 5, 31)
 

--- a/src/main/kotlin/no/nav/helse/flex/repository/DbRecordDataClasses.kt
+++ b/src/main/kotlin/no/nav/helse/flex/repository/DbRecordDataClasses.kt
@@ -47,7 +47,10 @@ data class SykepengesoknadDbRecord(
     val utenlandskSykmelding: Boolean,
     val egenmeldingsdagerFraSykmelding: String? = null,
     val forstegangssoknad: Boolean?,
-    val tidligereArbeidsgiverOrgnummer: String? = null
+    val tidligereArbeidsgiverOrgnummer: String? = null,
+    val inntektsopplysningerNyKvittering: Boolean? = null,
+    val inntektsopplysningerInnsendingId: String? = null,
+    val inntektsopplysningerInnsendingDokumenter: String? = null
 )
 
 data class SporsmalDbRecord(

--- a/src/main/kotlin/no/nav/helse/flex/sending/SoknadSender.kt
+++ b/src/main/kotlin/no/nav/helse/flex/sending/SoknadSender.kt
@@ -1,25 +1,17 @@
 package no.nav.helse.flex.sending
 
-import no.nav.helse.flex.domain.Arbeidssituasjon
 import no.nav.helse.flex.domain.Avsendertype
 import no.nav.helse.flex.domain.Soknadstatus
 import no.nav.helse.flex.domain.Soknadstatus.NY
 import no.nav.helse.flex.domain.Soknadstatus.UTKAST_TIL_KORRIGERING
-import no.nav.helse.flex.domain.Soknadstype
 import no.nav.helse.flex.domain.Sykepengesoknad
-import no.nav.helse.flex.inntektsopplysninger.dokumenterSomSkalSendes
 import no.nav.helse.flex.kafka.producer.SoknadProducer
-import no.nav.helse.flex.logger
 import no.nav.helse.flex.repository.SvarDAO
 import no.nav.helse.flex.repository.SykepengesoknadDAO
 import no.nav.helse.flex.repository.SykepengesoknadRepository
 import no.nav.helse.flex.repository.normaliser
 import no.nav.helse.flex.service.FolkeregisterIdenter
 import no.nav.helse.flex.service.MottakerAvSoknadService
-import no.nav.helse.flex.soknadsopprettelse.INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET
-import no.nav.helse.flex.soknadsopprettelse.INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET_JA
-import no.nav.helse.flex.soknadsopprettelse.INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET_NEI
-import no.nav.helse.flex.soknadsopprettelse.INNTEKTSOPPLYSNINGER_VARIG_ENDRING_25_PROSENT
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -39,7 +31,7 @@ class SoknadSender(
         avsendertype: Avsendertype,
         dodsdato: LocalDate?,
         identer: FolkeregisterIdenter
-    ) {
+    ): Sykepengesoknad {
         if (sykepengesoknad.status !in listOf(NY, UTKAST_TIL_KORRIGERING)) {
             throw RuntimeException("Søknad ${sykepengesoknad.id} kan ikke gå i fra status ${sykepengesoknad.status} til SENDT.")
         }
@@ -64,12 +56,6 @@ class SoknadSender(
             .findByFnrIn(identer.alle())
             .finnOpprinneligSendt(sendtSoknad.normaliser().soknad)
 
-        try {
-            hentOgLagreOmNaringsdrivendeSendeInntektsopplysninger(sendtSoknad)
-        } catch (e: Exception) {
-            log.error("Feil ved henting og lagring av inntektsopplysninger for næringsdrivende. ${sendtSoknad.id}", e)
-        }
-
         soknadProducer.soknadEvent(
             sykepengesoknad = sendtSoknad,
             mottaker = mottaker,
@@ -77,65 +63,7 @@ class SoknadSender(
             dodsdato = dodsdato,
             opprinneligSendt = opprinneligSendt
         )
-    }
 
-    private val log = logger()
-
-    fun Sykepengesoknad.skalHaDokumenter(): Boolean {
-        getSporsmalMedTagOrNull(INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET_JA)?.let {
-            if (it.forsteSvar == "CHECKED") {
-                return true
-            }
-        }
-
-        getSporsmalMedTagOrNull(INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET_NEI)?.let { sporsmal1 ->
-            if (sporsmal1.forsteSvar == "CHECKED") {
-                getSporsmalMedTagOrNull(INNTEKTSOPPLYSNINGER_VARIG_ENDRING_25_PROSENT)?.let {
-                    if (it.forsteSvar == "JA") {
-                        return true
-                    }
-                }
-            }
-        }
-        return false
-    }
-
-    private fun hentOgLagreOmNaringsdrivendeSendeInntektsopplysninger(soknad: Sykepengesoknad) {
-        if (soknad.arbeidssituasjon != Arbeidssituasjon.NAERINGSDRIVENDE) {
-            return
-        }
-
-        if (!listOf(
-                Soknadstype.GRADERT_REISETILSKUDD,
-                Soknadstype.SELVSTENDIGE_OG_FRILANSERE
-            ).contains(soknad.soknadstype)
-        ) {
-            return
-        }
-
-        if (soknad.forstegangssoknad != true) {
-            return
-        }
-
-        val erNyKvittering = soknad.getSporsmalMedTagOrNull(INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET) != null
-
-        sykepengesoknadRepository.findBySykepengesoknadUuid(soknad.id)?.let { sykepengeSoknad ->
-            val oppdatertSykepengeSoknad = if (soknad.skalHaDokumenter()) {
-                val dokumenter = dokumenterSomSkalSendes(LocalDate.now()).joinToString(",")
-                val innsendingsId = "TODO"
-
-                sykepengeSoknad.copy(
-                    inntektsopplysningerNyKvittering = erNyKvittering,
-                    inntektsopplysningerInnsendingId = innsendingsId,
-                    inntektsopplysningerInnsendingDokumenter = dokumenter
-                )
-            } else {
-                sykepengeSoknad.copy(
-                    inntektsopplysningerNyKvittering = erNyKvittering
-                )
-            }
-
-            sykepengesoknadRepository.save(oppdatertSykepengeSoknad)
-        }
+        return sendtSoknad
     }
 }

--- a/src/main/kotlin/no/nav/helse/flex/sending/SoknadSender.kt
+++ b/src/main/kotlin/no/nav/helse/flex/sending/SoknadSender.kt
@@ -1,17 +1,25 @@
 package no.nav.helse.flex.sending
 
+import no.nav.helse.flex.domain.Arbeidssituasjon
 import no.nav.helse.flex.domain.Avsendertype
 import no.nav.helse.flex.domain.Soknadstatus
 import no.nav.helse.flex.domain.Soknadstatus.NY
 import no.nav.helse.flex.domain.Soknadstatus.UTKAST_TIL_KORRIGERING
+import no.nav.helse.flex.domain.Soknadstype
 import no.nav.helse.flex.domain.Sykepengesoknad
+import no.nav.helse.flex.inntektsopplysninger.dokumenterSomSkalSendes
 import no.nav.helse.flex.kafka.producer.SoknadProducer
+import no.nav.helse.flex.logger
 import no.nav.helse.flex.repository.SvarDAO
 import no.nav.helse.flex.repository.SykepengesoknadDAO
 import no.nav.helse.flex.repository.SykepengesoknadRepository
 import no.nav.helse.flex.repository.normaliser
 import no.nav.helse.flex.service.FolkeregisterIdenter
 import no.nav.helse.flex.service.MottakerAvSoknadService
+import no.nav.helse.flex.soknadsopprettelse.INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET
+import no.nav.helse.flex.soknadsopprettelse.INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET_JA
+import no.nav.helse.flex.soknadsopprettelse.INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET_NEI
+import no.nav.helse.flex.soknadsopprettelse.INNTEKTSOPPLYSNINGER_VARIG_ENDRING_25_PROSENT
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -25,6 +33,7 @@ class SoknadSender(
     private val soknadProducer: SoknadProducer,
     private val sykepengesoknadRepository: SykepengesoknadRepository
 ) {
+
     fun sendSoknad(
         sykepengesoknad: Sykepengesoknad,
         avsendertype: Avsendertype,
@@ -55,6 +64,13 @@ class SoknadSender(
             .findByFnrIn(identer.alle())
             .finnOpprinneligSendt(sendtSoknad.normaliser().soknad)
 
+        try {
+
+            hentOgLagreOmNaringsdrivendeSendeInntektsopplysninger(sendtSoknad)
+        } catch (e: Exception) {
+            log.error("Feil ved henting og lagring av inntektsopplysninger for næringsdrivende. ${sendtSoknad.id}", e)
+        }
+
         soknadProducer.soknadEvent(
             sykepengesoknad = sendtSoknad,
             mottaker = mottaker,
@@ -62,5 +78,65 @@ class SoknadSender(
             dodsdato = dodsdato,
             opprinneligSendt = opprinneligSendt
         )
+    }
+
+    private val log = logger()
+
+    fun Sykepengesoknad.skalHaDokumenter(): Boolean {
+        getSporsmalMedTagOrNull(INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET_JA)?.let {
+            if (it.forsteSvar == "CHECKED") {
+                return true
+            }
+        }
+
+        getSporsmalMedTagOrNull(INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET_NEI)?.let { sporsmal1 ->
+            if (sporsmal1.forsteSvar == "CHECKED") {
+                getSporsmalMedTagOrNull(INNTEKTSOPPLYSNINGER_VARIG_ENDRING_25_PROSENT)?.let {
+                    if (it.forsteSvar == "JA") {
+                        return true
+                    }
+                }
+            }
+        }
+        return false
+    }
+
+    private fun hentOgLagreOmNaringsdrivendeSendeInntektsopplysninger(soknad: Sykepengesoknad) {
+        if (soknad.arbeidssituasjon != Arbeidssituasjon.NAERINGSDRIVENDE) {
+            return
+        }
+
+        if (!listOf(
+                Soknadstype.GRADERT_REISETILSKUDD,
+                Soknadstype.SELVSTENDIGE_OG_FRILANSERE
+            ).contains(soknad.soknadstype)
+        ) {
+            return
+        }
+
+        if (soknad.forstegangssoknad != true) {
+            return
+        }
+
+        val erNyKvittering = soknad.getSporsmalMedTagOrNull(INNTEKTSOPPLYSNINGER_NY_I_ARBEIDSLIVET) != null
+
+        sykepengesoknadRepository.findBySykepengesoknadUuid(soknad.id)?.let { sykepengeSoknad ->
+            val oppdatertSykepengeSoknad = if (soknad.skalHaDokumenter()) {
+                val dokumenter = dokumenterSomSkalSendes(LocalDate.now()).joinToString(",")
+                val innsendingsId = "TODO"
+
+                sykepengeSoknad.copy(
+                    inntektsopplysningerNyKvittering = erNyKvittering,
+                    inntektsopplysningerInnsendingId = innsendingsId,
+                    inntektsopplysningerInnsendingDokumenter = dokumenter
+                )
+            } else {
+                sykepengeSoknad.copy(
+                    inntektsopplysningerNyKvittering = erNyKvittering
+                )
+            }
+
+            sykepengesoknadRepository.save(oppdatertSykepengeSoknad)
+        }
     }
 }

--- a/src/main/kotlin/no/nav/helse/flex/sending/SoknadSender.kt
+++ b/src/main/kotlin/no/nav/helse/flex/sending/SoknadSender.kt
@@ -65,7 +65,6 @@ class SoknadSender(
             .finnOpprinneligSendt(sendtSoknad.normaliser().soknad)
 
         try {
-
             hentOgLagreOmNaringsdrivendeSendeInntektsopplysninger(sendtSoknad)
         } catch (e: Exception) {
             log.error("Feil ved henting og lagring av inntektsopplysninger for næringsdrivende. ${sendtSoknad.id}", e)

--- a/src/main/resources/db/migration/V34__inntektsopplysninger_innsending.sql
+++ b/src/main/resources/db/migration/V34__inntektsopplysninger_innsending.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sykepengesoknad
+    ADD COLUMN inntektsopplysninger_ny_kvittering         BOOLEAN,
+    ADD COLUMN inntektsopplysninger_innsending_id         VARCHAR,
+    ADD COLUMN inntektsopplysninger_innsending_dokumenter VARCHAR;
+

--- a/src/test/kotlin/no/nav/helse/flex/inntektsopplysninger/HvilkeDokumenterTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/inntektsopplysninger/HvilkeDokumenterTest.kt
@@ -1,0 +1,50 @@
+package no.nav.helse.flex.inntektsopplysninger
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class HvilkeDokumenterTest {
+    @Test
+    fun `skal returnere regnskap for forrige år, skattemelding og næringsSpesifikasjon optional før 31 mai`() {
+        val testDato = LocalDate.of(2023, 5, 30)
+        val forventet = listOf(
+            DokumentTyper.REGNSKAP_FORRIGE_AAR,
+            DokumentTyper.SKATTEMELDING_OPTIONAL,
+            DokumentTyper.NARINGSSPESIFIKASJON_OPTIONAL
+        )
+        assertEquals(forventet, dokumenterSomkalSendes(testDato))
+    }
+
+    @Test
+    fun `skal returnere skattemelding og næringsSpesifikasjon etter 31 mai og før siste tertial`() {
+        val testDato = LocalDate.of(2023, 6, 1)
+        val forventet = listOf(
+            DokumentTyper.SKATTEMELDING,
+            DokumentTyper.NARINGSSPESIFIKASJON
+        )
+        assertEquals(forventet, dokumenterSomkalSendes(testDato))
+    }
+
+    @Test
+    fun `skal returnere skattemelding, næringsSpesifikasjon og foreløpig regnskap i siste tertial`() {
+        val testDato = LocalDate.of(2023, 9, 1)
+        val forventet = listOf(
+            DokumentTyper.SKATTEMELDING,
+            DokumentTyper.NARINGSSPESIFIKASJON,
+            DokumentTyper.REGNSKAP_FORELOPIG
+        )
+        assertEquals(forventet, dokumenterSomkalSendes(testDato))
+    }
+
+    @Test
+    fun `skal returnere skattemelding, næringsSpesifikasjon og foreløpig regnskap etter siste tertial`() {
+        val testDato = LocalDate.of(2023, 12, 31)
+        val forventet = listOf(
+            DokumentTyper.SKATTEMELDING,
+            DokumentTyper.NARINGSSPESIFIKASJON,
+            DokumentTyper.REGNSKAP_FORELOPIG
+        )
+        assertEquals(forventet, dokumenterSomkalSendes(testDato))
+    }
+}

--- a/src/test/kotlin/no/nav/helse/flex/inntektsopplysninger/HvilkeDokumenterTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/inntektsopplysninger/HvilkeDokumenterTest.kt
@@ -9,42 +9,42 @@ class HvilkeDokumenterTest {
     fun `skal returnere regnskap for forrige år, skattemelding og næringsSpesifikasjon optional før 31 mai`() {
         val testDato = LocalDate.of(2023, 5, 30)
         val forventet = listOf(
-            DokumentTyper.REGNSKAP_FORRIGE_AAR,
-            DokumentTyper.SKATTEMELDING_OPTIONAL,
-            DokumentTyper.NARINGSSPESIFIKASJON_OPTIONAL
+            InntektsopplysningerDokumentType.REGNSKAP_FORRIGE_AAR,
+            InntektsopplysningerDokumentType.SKATTEMELDING_OPTIONAL,
+            InntektsopplysningerDokumentType.NARINGSSPESIFIKASJON_OPTIONAL
         )
-        assertEquals(forventet, dokumenterSomkalSendes(testDato))
+        assertEquals(forventet, dokumenterSomSkalSendes(testDato))
     }
 
     @Test
     fun `skal returnere skattemelding og næringsSpesifikasjon etter 31 mai og før siste tertial`() {
         val testDato = LocalDate.of(2023, 6, 1)
         val forventet = listOf(
-            DokumentTyper.SKATTEMELDING,
-            DokumentTyper.NARINGSSPESIFIKASJON
+            InntektsopplysningerDokumentType.SKATTEMELDING,
+            InntektsopplysningerDokumentType.NARINGSSPESIFIKASJON
         )
-        assertEquals(forventet, dokumenterSomkalSendes(testDato))
+        assertEquals(forventet, dokumenterSomSkalSendes(testDato))
     }
 
     @Test
     fun `skal returnere skattemelding, næringsSpesifikasjon og foreløpig regnskap i siste tertial`() {
         val testDato = LocalDate.of(2023, 9, 1)
         val forventet = listOf(
-            DokumentTyper.SKATTEMELDING,
-            DokumentTyper.NARINGSSPESIFIKASJON,
-            DokumentTyper.REGNSKAP_FORELOPIG
+            InntektsopplysningerDokumentType.SKATTEMELDING,
+            InntektsopplysningerDokumentType.NARINGSSPESIFIKASJON,
+            InntektsopplysningerDokumentType.REGNSKAP_FORELOPIG
         )
-        assertEquals(forventet, dokumenterSomkalSendes(testDato))
+        assertEquals(forventet, dokumenterSomSkalSendes(testDato))
     }
 
     @Test
     fun `skal returnere skattemelding, næringsSpesifikasjon og foreløpig regnskap etter siste tertial`() {
         val testDato = LocalDate.of(2023, 12, 31)
         val forventet = listOf(
-            DokumentTyper.SKATTEMELDING,
-            DokumentTyper.NARINGSSPESIFIKASJON,
-            DokumentTyper.REGNSKAP_FORELOPIG
+            InntektsopplysningerDokumentType.SKATTEMELDING,
+            InntektsopplysningerDokumentType.NARINGSSPESIFIKASJON,
+            InntektsopplysningerDokumentType.REGNSKAP_FORELOPIG
         )
-        assertEquals(forventet, dokumenterSomkalSendes(testDato))
+        assertEquals(forventet, dokumenterSomSkalSendes(testDato))
     }
 }


### PR DESCRIPTION
- Bruker svarene i søknaden til å avklare hvilke dokumenter næringsdrivende må
ettersende.
- Bruker samme logikk til vise gammel eller ny kvittering.
- Lagrer innsendingsId, dokumenter og kvitteringstype i databasen.