### PR TITLE
Flagg aktiverte søknader som julesøknader

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/julesoknad/ProsesserJulesoknadkandidat.kt
+++ b/src/main/kotlin/no/nav/helse/flex/julesoknad/ProsesserJulesoknadkandidat.kt
@@ -60,6 +60,9 @@ class ProsesserJulesoknadkandidat(
                 }
                 log.info("Arbeidsgiver forskutterer ikke julesøknadkandidat $julesoknadkandidat, aktiverer søknad og sletter kandidat")
 
+                // Gjør at vi kan identifisere søknaden som en julesøknad i sykepengesoknad-frontend.
+                sykepengesoknadRepository.settErAktivertJulesoknadKandidat(soknad.id!!)
+
                 aktiveringProducer.leggPaAktiveringTopic(AktiveringBestilling(soknad.fnr, soknad.sykepengesoknadUuid))
                 julesoknadkandidatDAO.slettJulesoknadkandidat(julesoknadkandidat.julesoknadkandidatId)
                 return

--- a/src/main/kotlin/no/nav/helse/flex/repository/JulesoknadkandidatDAO.kt
+++ b/src/main/kotlin/no/nav/helse/flex/repository/JulesoknadkandidatDAO.kt
@@ -16,12 +16,13 @@ class JulesoknadkandidatDAO(
     fun hentJulesoknadkandidater(): List<Julesoknadkandidat> {
         return namedParameterJdbcTemplate.query(
             """
-                    SELECT ID, SYKEPENGESOKNAD_UUID FROM JULESOKNADKANDIDAT
-                    """,
+            SELECT id, sykepengesoknad_uuid 
+            FROM julesoknadkandidat
+            """,
         ) { resultSet, _ ->
             Julesoknadkandidat(
-                julesoknadkandidatId = resultSet.getString("ID"),
-                sykepengesoknadUuid = resultSet.getString("SYKEPENGESOKNAD_UUID"),
+                julesoknadkandidatId = resultSet.getString("id"),
+                sykepengesoknadUuid = resultSet.getString("sykepengesoknad_uuid"),
             )
         }
     }

--- a/src/main/kotlin/no/nav/helse/flex/repository/SykepengesoknadRepository.kt
+++ b/src/main/kotlin/no/nav/helse/flex/repository/SykepengesoknadRepository.kt
@@ -1,5 +1,6 @@
 package no.nav.helse.flex.repository
 
+import org.springframework.data.jdbc.repository.query.Modifying
 import org.springframework.data.jdbc.repository.query.Query
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
@@ -14,6 +15,26 @@ interface SykepengesoknadRepository : CrudRepository<SykepengesoknadDbRecord, St
     fun findByFnrIn(fnrs: List<String>): List<SykepengesoknadDbRecord>
 
     fun findBySykmeldingUuid(sykmeldingUuid: String): List<SykepengesoknadDbRecord>
+
+    @Modifying
+    @Query(
+        """
+        UPDATE sykepengesoknad
+        SET aktivert_julesoknad_kandidat = true
+        WHERE id = :id
+          AND status = 'FREMTIDIG'
+        """,
+    )
+    fun settErAktivertJulesoknadKandidat(id: String): Boolean
+
+    @Query(
+        """
+        SELECT aktivert_julesoknad_kandidat
+        FROM sykepengesoknad
+        WHERE sykepengesoknad_uuid = :id
+        """,
+    )
+    fun erAktivertJulesoknadKandidat(id: String): Boolean?
 
     @Query(
         """

--- a/src/main/resources/db/migration/V42__julesoknad.sql
+++ b/src/main/resources/db/migration/V42__julesoknad.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sykepengesoknad
+    ADD COLUMN aktivert_julesoknad_kandidat BOOLEAN NULL;

--- a/src/test/kotlin/no/nav/helse/flex/julesoknad/JulesoknadDaoTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/julesoknad/JulesoknadDaoTest.kt
@@ -2,6 +2,7 @@ package no.nav.helse.flex.julesoknad
 
 import no.nav.helse.flex.FellesTestOppsett
 import no.nav.helse.flex.repository.JulesoknadkandidatDAO
+import org.amshove.kluent.shouldHaveSize
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
@@ -14,9 +15,11 @@ class JulesoknadDaoTest : FellesTestOppsett() {
     private lateinit var julesoknadkandidatDAO: JulesoknadkandidatDAO
 
     @Test
-    fun `Takler duplikater`() {
+    fun `Samme julesoknad lagres bare en gang`() {
         val uuid = UUID.randomUUID().toString()
         julesoknadkandidatDAO.lagreJulesoknadkandidat(uuid)
         julesoknadkandidatDAO.lagreJulesoknadkandidat(uuid)
+
+        julesoknadkandidatDAO.hentJulesoknadkandidater() shouldHaveSize 1
     }
 }


### PR DESCRIPTION
Gjør at vi kan sporet hvilke søknader som var julesøknadkandidater, og vi kan bruke det samme flagget i frontend.