### PR TITLE
Takle manglende felt fra Grunnbeløp API

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/client/grunnbeloep/GrunnbeloepClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/client/grunnbeloep/GrunnbeloepClient.kt
@@ -51,11 +51,12 @@ class GrunnbeloepClient(
     }
 }
 
+// TODO: Trenger ikke grunnbeløpPerMaaned, omregningsfaktor og virkningstidspunktForMinsteinntekt når vi bruker egen objectMapper.
 data class GrunnbeloepResponse(
     val dato: String,
     val grunnbeløp: Int,
     val grunnbeløpPerMaaned: Int,
     val gjennomsnittPerÅr: Int,
     val omregningsfaktor: Float,
-    val virkningstidspunktForMinsteinntekt: String,
+    val virkningstidspunktForMinsteinntekt: String? = null,
 ) : Serializable

--- a/src/test/kotlin/no/nav/helse/flex/mockdispatcher/GrunnbeloepApiMockDispatcher.kt
+++ b/src/test/kotlin/no/nav/helse/flex/mockdispatcher/GrunnbeloepApiMockDispatcher.kt
@@ -124,6 +124,13 @@ object GrunnbeloepApiMockDispatcher : QueueDispatcher() {
                 val responses =
                     listOf(
                         GrunnbeloepResponse(
+                            dato = "2012-05-01",
+                            grunnbeløp = 82122,
+                            grunnbeløpPerMaaned = 6844,
+                            gjennomsnittPerÅr = 81153,
+                            omregningsfaktor = 1.036685f,
+                        ),
+                        GrunnbeloepResponse(
                             dato = "2013-05-01",
                             grunnbeløp = 85245,
                             grunnbeløpPerMaaned = 7104,

--- a/src/test/kotlin/no/nav/helse/flex/service/GrunnbeloepServiceTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/service/GrunnbeloepServiceTest.kt
@@ -48,7 +48,7 @@ class GrunnbeloepServiceTest : FellesTestOppsett() {
         verify(grunnbeloepClient, times(1)).hentGrunnbeloepHistorikk(andreDato.minusYears(5))
 
         forsteResponse.size `should be equal to` 6
-        andreResponse.size `should be equal to` 12
+        andreResponse.size `should be equal to` 13
 
         forsteResponse[2019]?.grunnbeløp `should be equal to` 99858
         andreResponse[2013]?.grunnbeløp `should be equal to` 85245


### PR DESCRIPTION
Verdier fra 2012 (som vi får returnert når vi spør om 2013-01-01) mangler feltet virkningstidspunktForMinsteinntekt sånn at vi får deserialiseringsfeil.