### PR TITLE
Ikke retry kall til Sigrun for logiske feil

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/client/sigrun/PensjongivendeInntektClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/client/sigrun/PensjongivendeInntektClient.kt
@@ -18,7 +18,7 @@ class PensjongivendeInntektClient(
     @Value("\${SIGRUN_URL}")
     private val url: String,
 ) {
-    @Retryable
+    @Retryable(noRetryFor = [PensjongivendeInntektClientException::class])
     fun hentPensjonsgivendeInntekt(
         fnr: String,
         inntektsAar: Int,

--- a/src/main/kotlin/no/nav/helse/flex/client/sigrun/PensjongivendeInntektClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/client/sigrun/PensjongivendeInntektClient.kt
@@ -18,7 +18,7 @@ class PensjongivendeInntektClient(
     @Value("\${SIGRUN_URL}")
     private val url: String,
 ) {
-    @Retryable(noRetryFor = [PensjongivendeInntektClientException::class])
+    @Retryable(noRetryFor = [PensjongivendeInntektClientException::class], maxAttempts = 3)
     fun hentPensjonsgivendeInntekt(
         fnr: String,
         inntektsAar: Int,

--- a/src/main/kotlin/no/nav/helse/flex/client/sigrun/PensjongivendeInntektClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/client/sigrun/PensjongivendeInntektClient.kt
@@ -9,6 +9,9 @@ import org.springframework.web.client.RestTemplate
 import org.springframework.web.util.UriComponentsBuilder
 import java.util.*
 
+class PensjongivendeInntektClientException(message: String, cause: Throwable? = null) :
+    RuntimeException(message, cause)
+
 @Component
 class PensjongivendeInntektClient(
     private val persongivendeInntektRestTemplate: RestTemplate,
@@ -99,9 +102,7 @@ class PensjongivendeInntektClient(
 
                     else -> "Klientfeil ved kall mot Sigrun: ${e.statusCode} - ${e.message}"
                 }
-            throw RuntimeException(feilmelding, e)
-        } catch (e: Exception) {
-            throw RuntimeException("Feil ved kall mot Sigrun: ${e.message}", e)
+            throw PensjongivendeInntektClientException(feilmelding, e)
         }
     }
 }

--- a/src/main/kotlin/no/nav/helse/flex/service/SykepengegrunnlagForNaeringsdrivende.kt
+++ b/src/main/kotlin/no/nav/helse/flex/service/SykepengegrunnlagForNaeringsdrivende.kt
@@ -60,7 +60,7 @@ class SykepengegrunnlagForNaeringsdrivende(
         val grunnbeloepPaaSykmeldingstidspunkt = grunnbeloepSisteFemAar[sykmeldingstidspunkt]!!.grunnbeløp
 
         val pensjonsgivendeInntekter =
-            hentPensjonsgivendeInntektForTreSisteArene(
+            hentPensjonsgivendeInntektForTreSisteAar(
                 soknad.fnr,
                 sykmeldingstidspunkt,
             )?.filter { it.pensjonsgivendeInntekt.isNotEmpty() }
@@ -95,7 +95,7 @@ class SykepengegrunnlagForNaeringsdrivende(
         )
     }
 
-    fun hentPensjonsgivendeInntektForTreSisteArene(
+    fun hentPensjonsgivendeInntektForTreSisteAar(
         fnr: String,
         sykmeldingstidspunkt: Int,
     ): List<HentPensjonsgivendeInntektResponse>? {

--- a/src/test/kotlin/no/nav/helse/flex/FellesTestOppsett.kt
+++ b/src/test/kotlin/no/nav/helse/flex/FellesTestOppsett.kt
@@ -47,11 +47,12 @@ abstract class FellesTestOppsett {
     companion object {
         val pdlMockWebserver: MockWebServer
         val medlemskapMockWebServer: MockWebServer
+        val pensjonsgivendeInntektMockWebServer: MockWebServer
         private val inntektskomponentenMockWebServer: MockWebServer
         private val eregMockWebServer: MockWebServer
         private val yrkesskadeMockWebServer: MockWebServer
         private val innsendingApiMockWebServer: MockWebServer
-        private val pensjonsgivendeInntektMockWebServer: MockWebServer
+
         private val grunnbeloepApiMockWebServer: MockWebServer
 
         init {

--- a/src/test/kotlin/no/nav/helse/flex/sigrun/SigrunInnhentingsregelTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/sigrun/SigrunInnhentingsregelTest.kt
@@ -1,11 +1,14 @@
 package no.nav.helse.flex.sigrun
 
 import no.nav.helse.flex.FellesTestOppsett
+import no.nav.helse.flex.client.sigrun.PensjongivendeInntektClientException
 import no.nav.helse.flex.mock.opprettNyNaeringsdrivendeSoknad
+import no.nav.helse.flex.mockdispatcher.SigrunMockDispatcher
 import org.amshove.kluent.`should be`
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should not be`
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.Instant
 import java.time.LocalDate
 
@@ -145,4 +148,53 @@ class SigrunInnhentingsregelTest : FellesTestOppsett() {
 
         result `should be` null
     } // personUtenPensjonsgivendeInntektAlleÅr
+
+    @Test
+    fun `Det gjøres ikke retry for exceptions kastet på grunn av feil med semantikk`() {
+        SigrunMockDispatcher.nullstillAntallKall()
+
+        val soknad =
+            opprettNyNaeringsdrivendeSoknad().copy(
+                fnr = "01017011111",
+                startSykeforlop = LocalDate.now(),
+                fom = LocalDate.now().minusDays(30),
+                tom = LocalDate.now().minusDays(1),
+                sykmeldingSkrevet = Instant.now(),
+                aktivertDato = LocalDate.now().minusDays(30),
+            )
+
+        assertThrows<PensjongivendeInntektClientException> {
+            sykepengegrunnlagForNaeringsdrivende.hentPensjonsgivendeInntektForTreSisteAar(
+                soknad.fnr,
+                soknad.startSykeforlop!!.year,
+            )
+        }
+
+        SigrunMockDispatcher.hentAntallKall() `should be` 1
+    }
+
+    @Test
+    fun `Det gjøres retry når det kastes exception som ikke er på grunn av feil med semantikk`() {
+        SigrunMockDispatcher.nullstillAntallKall()
+
+        val soknad =
+            opprettNyNaeringsdrivendeSoknad().copy(
+                fnr = "01017022222",
+                startSykeforlop = LocalDate.now(),
+                fom = LocalDate.now().minusDays(30),
+                tom = LocalDate.now().minusDays(1),
+                sykmeldingSkrevet = Instant.now(),
+                aktivertDato = LocalDate.now().minusDays(30),
+            )
+
+        assertThrows<RuntimeException> {
+            sykepengegrunnlagForNaeringsdrivende.hentPensjonsgivendeInntektForTreSisteAar(
+                soknad.fnr,
+                soknad.startSykeforlop!!.year,
+            )
+        }
+
+        // @Retryable(maxAttempts = 3)
+        SigrunMockDispatcher.hentAntallKall() `should be` 3
+    }
 }

--- a/src/test/kotlin/no/nav/helse/flex/sigrun/SigrunInnhentingsregelTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/sigrun/SigrunInnhentingsregelTest.kt
@@ -22,7 +22,7 @@ class SigrunInnhentingsregelTest : FellesTestOppsett() {
                 aktivertDato = LocalDate.now().minusDays(30),
             )
         val result =
-            sykepengegrunnlagForNaeringsdrivende.hentPensjonsgivendeInntektForTreSisteArene(
+            sykepengegrunnlagForNaeringsdrivende.hentPensjonsgivendeInntektForTreSisteAar(
                 soknad.fnr,
                 soknad.startSykeforlop!!.year,
             )
@@ -50,7 +50,7 @@ class SigrunInnhentingsregelTest : FellesTestOppsett() {
                 aktivertDato = LocalDate.now().minusDays(30),
             )
         val result =
-            sykepengegrunnlagForNaeringsdrivende.hentPensjonsgivendeInntektForTreSisteArene(
+            sykepengegrunnlagForNaeringsdrivende.hentPensjonsgivendeInntektForTreSisteAar(
                 soknad.fnr,
                 soknad.startSykeforlop!!.year,
             )
@@ -70,7 +70,7 @@ class SigrunInnhentingsregelTest : FellesTestOppsett() {
                 aktivertDato = LocalDate.now().minusDays(30),
             )
         val result =
-            sykepengegrunnlagForNaeringsdrivende.hentPensjonsgivendeInntektForTreSisteArene(
+            sykepengegrunnlagForNaeringsdrivende.hentPensjonsgivendeInntektForTreSisteAar(
                 soknad.fnr,
                 soknad.startSykeforlop!!.year,
             )
@@ -90,7 +90,7 @@ class SigrunInnhentingsregelTest : FellesTestOppsett() {
                 aktivertDato = LocalDate.now().minusDays(30),
             )
         val result =
-            sykepengegrunnlagForNaeringsdrivende.hentPensjonsgivendeInntektForTreSisteArene(
+            sykepengegrunnlagForNaeringsdrivende.hentPensjonsgivendeInntektForTreSisteAar(
                 soknad.fnr,
                 soknad.startSykeforlop!!.year,
             )
@@ -110,7 +110,7 @@ class SigrunInnhentingsregelTest : FellesTestOppsett() {
                 aktivertDato = LocalDate.now().minusDays(30),
             )
         val result =
-            sykepengegrunnlagForNaeringsdrivende.hentPensjonsgivendeInntektForTreSisteArene(
+            sykepengegrunnlagForNaeringsdrivende.hentPensjonsgivendeInntektForTreSisteAar(
                 soknad.fnr,
                 soknad.startSykeforlop!!.year,
             )
@@ -138,7 +138,7 @@ class SigrunInnhentingsregelTest : FellesTestOppsett() {
                 aktivertDato = LocalDate.now().minusDays(30),
             )
         val result =
-            sykepengegrunnlagForNaeringsdrivende.hentPensjonsgivendeInntektForTreSisteArene(
+            sykepengegrunnlagForNaeringsdrivende.hentPensjonsgivendeInntektForTreSisteAar(
                 soknad.fnr,
                 soknad.startSykeforlop!!.year,
             )


### PR DESCRIPTION
API for pensjonsgivende inntekt (Sigrun) bruker HTTP feilkoder til å beskrive feilsituasjoner det
ikke er mulig å gjøre noe med ved hjelp av en retry. 

- Kaster en custom exception når det er kjente feilkoder fra Sigrun.
- Gjør retries for alle andre feil, men lar endelig exception boble opp til Kafka-lytter.
