### PR TITLE
Bruk FOM som sykmeldingstidspunkt

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/service/SykepengegrunnlagForNaeringsdrivende.kt
+++ b/src/main/kotlin/no/nav/helse/flex/service/SykepengegrunnlagForNaeringsdrivende.kt
@@ -25,9 +25,7 @@ class SykepengegrunnlagForNaeringsdrivende(
     private val log = logger()
 
     fun beregnSykepengegrunnlag(soknad: Sykepengesoknad): SykepengegrunnlagNaeringsdrivende? {
-        // TODO: Bruk sykmeldingstidspunkt i stedet for startSykeforlop.
-
-        val sykmeldingstidspunkt = soknad.startSykeforlop!!.year
+        val sykmeldingstidspunkt = soknad.fom!!.year
         val grunnbeloepSisteFemAar = grunnbeloepService.hentGrunnbeloepHistorikk(sykmeldingstidspunkt)
         val grunnbeloepPaaSykmeldingstidspunkt = grunnbeloepSisteFemAar[sykmeldingstidspunkt]!!.grunnbeløp
 


### PR DESCRIPTION
I stedet for startSyketilfelle, som kan være langt tilbake i tid.
