### PR TITLE
Splitt FriskTilArbeid perioder i søknader

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidService.kt
@@ -47,7 +47,7 @@ class FriskTilArbeidService(
         log.info("Hentet ${dbRecords.size} FriskTilArbeidVedtakStatus for med status NY.")
 
         dbRecords.forEach {
-            friskTilArbeidSoknadService.opprettSoknader(it, ::defaultSoknadPeriodeGenerator)
+            friskTilArbeidSoknadService.opprettSoknader(it)
         }
     }
 }

--- a/src/main/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidService.kt
@@ -47,7 +47,7 @@ class FriskTilArbeidService(
         log.info("Hentet ${dbRecords.size} FriskTilArbeidVedtakStatus for med status NY.")
 
         dbRecords.forEach {
-            friskTilArbeidSoknadService.opprettSoknad(it)
+            friskTilArbeidSoknadService.opprettSoknader(it, ::defaultSoknadPeriodeGenerator)
         }
     }
 }

--- a/src/main/kotlin/no/nav/helse/flex/kafka/producer/SoknadProducer.kt
+++ b/src/main/kotlin/no/nav/helse/flex/kafka/producer/SoknadProducer.kt
@@ -34,7 +34,6 @@ class SoknadProducer(
                 dodsdato = dodsdato,
                 opprinneligSendt = opprinneligSendt?.tilOsloLocalDateTime(),
             )
-
         kafkaProducer.produserMelding(sykepengesoknadDTO)
     }
 

--- a/src/main/kotlin/no/nav/helse/flex/repository/SykepengesoknadRepository.kt
+++ b/src/main/kotlin/no/nav/helse/flex/repository/SykepengesoknadRepository.kt
@@ -10,6 +10,8 @@ import java.time.LocalDate
 interface SykepengesoknadRepository : CrudRepository<SykepengesoknadDbRecord, String> {
     fun findBySykepengesoknadUuid(sykepengesoknadUuid: String): SykepengesoknadDbRecord?
 
+    fun findByFriskTilArbeidVedtakId(vedtakId: String): List<SykepengesoknadDbRecord>
+
     fun findBySykepengesoknadUuidIn(sykepengesoknadUuid: List<String>): List<SykepengesoknadDbRecord>
 
     fun findByFnrIn(fnrs: List<String>): List<SykepengesoknadDbRecord>

--- a/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/OpprettSoknadService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/OpprettSoknadService.kt
@@ -147,7 +147,7 @@ class OpprettSoknadService(
         if (skalAktiveres) {
             return AktiveringBestilling(this.fnr, this.id)
         }
-        // Publiserer søknad med status FREMTIDIG som aktiveres av Cron-jobb senere.
+        // Publiserer søknad med status FREMTIDIG som aktiveres av cron-jobb senere.
         soknadProducer.soknadEvent(this)
 
         return null

--- a/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/OpprettSoknadService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/OpprettSoknadService.kt
@@ -147,7 +147,7 @@ class OpprettSoknadService(
         if (skalAktiveres) {
             return AktiveringBestilling(this.fnr, this.id)
         }
-        // Publiserer søknad med status FREMTIDIG som aktiveres av cron-jobb senere.
+        // Publiserer søknad med status FREMTIDIG som aktiveres av Cron-jobb senere.
         soknadProducer.soknadEvent(this)
 
         return null

--- a/src/test/kotlin/no/nav/helse/flex/fakes/SykepengesoknadRepositoryFake.kt
+++ b/src/test/kotlin/no/nav/helse/flex/fakes/SykepengesoknadRepositoryFake.kt
@@ -16,6 +16,10 @@ class SykepengesoknadRepositoryFake : SykepengesoknadRepository {
         TODO("Not yet implemented")
     }
 
+    override fun findByFriskTilArbeidVedtakId(vedtakId: String): List<SykepengesoknadDbRecord> {
+        TODO("Not yet implemented")
+    }
+
     override fun findBySykepengesoknadUuidIn(sykepengesoknadUuid: List<String>): List<SykepengesoknadDbRecord> {
         TODO("Not yet implemented")
     }

--- a/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidIntegrationTest.kt
@@ -44,12 +44,15 @@ class FriskTilArbeidIntegrationTest() : FellesTestOppsett() {
 
     private val fnr = "11111111111"
 
-    // 2 perioder på 2 hele uker (14 dager) og en periode på én uke (7 dager).
-    val vedtaksperiode = LocalDate.of(2025, 2, 3) to LocalDate.of(2025, 3, 9)
-
     @Test
     @Order(1)
     fun `Mottar og lagrer VedtakStatusRecord med status FATTET`() {
+        // To 14-dagersperioder og én 7-dagersperiode.
+        val vedtaksperiode =
+            Vedtaksperiode(
+                periodeStart = LocalDate.of(2025, 2, 3),
+                periodeSlutt = LocalDate.of(2025, 3, 9),
+            )
         val fnr = fnr
         val key = fnr.asProducerRecordKey()
         val friskTilArbeidVedtakStatus = lagFriskTilArbeidVedtakStatus(fnr, Status.FATTET, vedtaksperiode)

--- a/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidRepositoryTest.kt
@@ -11,6 +11,7 @@ import org.amshove.kluent.shouldNotBe
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.*
 
@@ -78,10 +79,14 @@ class FriskTilArbeidRepositoryTest : FellesTestOppsett() {
         }
     }
 
-    private fun lagVerdierForLagring(fnr: String): VerdierForLagring {
+    private fun lagVerdierForLagring(
+        fnr: String,
+        fom: LocalDate? = LocalDate.now(),
+        tom: LocalDate? = LocalDate.now(),
+    ): VerdierForLagring {
         val uuid = UUID.randomUUID().toString()
         val key = fnr.asProducerRecordKey()
-        val vedtakStatus = lagFriskTilArbeidVedtakStatus(fnr, Status.FATTET)
+        val vedtakStatus = lagFriskTilArbeidVedtakStatus(fnr, Status.FATTET, fom!! to tom!!)
         return VerdierForLagring(uuid, key, vedtakStatus)
     }
 

--- a/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidRepositoryTest.kt
@@ -11,7 +11,6 @@ import org.amshove.kluent.shouldNotBe
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.*
 
@@ -79,15 +78,12 @@ class FriskTilArbeidRepositoryTest : FellesTestOppsett() {
         }
     }
 
-    private fun lagVerdierForLagring(
-        fnr: String,
-        fom: LocalDate? = LocalDate.now(),
-        tom: LocalDate? = LocalDate.now(),
-    ): VerdierForLagring {
-        val uuid = UUID.randomUUID().toString()
-        val key = fnr.asProducerRecordKey()
-        val vedtakStatus = lagFriskTilArbeidVedtakStatus(fnr, Status.FATTET, fom!! to tom!!)
-        return VerdierForLagring(uuid, key, vedtakStatus)
+    private fun lagVerdierForLagring(fnr: String): VerdierForLagring {
+        return VerdierForLagring(
+            uuid = UUID.randomUUID().toString(),
+            key = fnr.asProducerRecordKey(),
+            vedtakStatus = lagFriskTilArbeidVedtakStatus(fnr, Status.FATTET),
+        )
     }
 
     private fun FriskTilArbeidVedtakStatus.tilDbRecord(

--- a/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidServiceTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidServiceTest.kt
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
+import java.time.LocalDate
 import java.util.*
 
 @SpringBootTest(classes = [FriskTilArbeidServiceTestConfiguration::class])
@@ -92,7 +93,10 @@ class FriskTilArbeidServiceTest {
 class FakeFriskTilArbeidSoknadService(
     private val friskTilArbeidRepository: FriskTilArbeidRepository,
 ) : FriskTilArbeidSoknadService(friskTilArbeidRepository, null, null) {
-    override fun opprettSoknad(friskTilArbeidDbRecord: FriskTilArbeidVedtakDbRecord) {
+    override fun opprettSoknader(
+        friskTilArbeidDbRecord: FriskTilArbeidVedtakDbRecord,
+        periodGenerator: (LocalDate, LocalDate, Long) -> List<Pair<LocalDate, LocalDate>>,
+    ) {
         friskTilArbeidRepository.save(friskTilArbeidDbRecord.copy(behandletStatus = BehandletStatus.BEHANDLET))
     }
 }
@@ -100,14 +104,14 @@ class FakeFriskTilArbeidSoknadService(
 @Suppress("UNCHECKED_CAST")
 @TestConfiguration
 class FriskTilArbeidTestConfig {
-    // TODO: Fake avhengigheter i stedet for FriskTilArbeidSoknadService.
+    // TODO: Bytt ut med fakes av FriskTilArbeidSoknadService.
     @Bean
     @Qualifier("fakeFriskTilArbeidSoknadService")
     fun fakeFriskTilArbeidSoknadService(friskTilArbeidRepository: FriskTilArbeidRepository): FriskTilArbeidSoknadService {
         return FakeFriskTilArbeidSoknadService(friskTilArbeidRepository)
     }
 
-    // TODO: Bytt ut med en Fake som arver InMemoryCrudRepository.
+    // TODO: Bytt ut med utvidelse av InMemoryCrudRepository.
     @Bean
     @Qualifier("fakeFriskTilArbeidRepository")
     fun fakeFriskTilArbeidRepository(): FriskTilArbeidRepository {

--- a/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidSoknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidSoknadServiceTest.kt
@@ -1,0 +1,102 @@
+package no.nav.helse.flex.frisktilarbeid
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+class FriskTilArbeidSoknadServiceTest {
+    @Test
+    fun `Generer perioder for en måned med default periodelengde`() {
+        defaultSoknadPeriodeGenerator(
+            fom = LocalDate.of(2025, 1, 1),
+            tom = LocalDate.of(2025, 1, 31),
+        ).also { perioder ->
+            assertEquals(3, perioder.size)
+
+            val forventedePerioder =
+                listOf(
+                    ForventetPeriode("2025-01-01", "2025-01-14", 14L),
+                    ForventetPeriode("2025-01-15", "2025-01-28", 14L),
+                    ForventetPeriode("2025-01-29", "2025-01-31", 3L),
+                )
+            sammenlignPerioder(forventedePerioder, perioder)
+        }
+    }
+
+    @Test
+    fun `Generer perioder for en måned med angitt periodelengde`() {
+        defaultSoknadPeriodeGenerator(
+            fom = LocalDate.of(2025, 1, 1),
+            tom = LocalDate.of(2025, 1, 31),
+            periodeLengde = 7,
+        ).also {
+            assertEquals(5, it.size)
+
+            val forventedePerioder =
+                listOf(
+                    ForventetPeriode("2025-01-01", "2025-01-07", 7L),
+                    ForventetPeriode("2025-01-08", "2025-01-14", 7L),
+                    ForventetPeriode("2025-01-15", "2025-01-21", 7L),
+                    ForventetPeriode("2025-01-22", "2025-01-28", 7L),
+                    ForventetPeriode("2025-01-29", "2025-01-31", 3L),
+                )
+            sammenlignPerioder(forventedePerioder = forventedePerioder, generertePerioder = it)
+        }
+    }
+
+    @Test
+    fun `Generer perioder for en enkelt dag`() {
+        defaultSoknadPeriodeGenerator(
+            fom = LocalDate.of(2025, 1, 1),
+            tom = LocalDate.of(2025, 1, 1),
+        ).also { perioder ->
+            assertEquals(1, perioder.size)
+
+            val forventedePerioder =
+                listOf(
+                    ForventetPeriode("2025-01-01", "2025-01-01", 1L),
+                )
+
+            sammenlignPerioder(forventedePerioder, perioder)
+        }
+    }
+
+    @Test
+    fun `Generering av perioder feiler når tom er før tom`() {
+        assertThrows<IllegalArgumentException> {
+            defaultSoknadPeriodeGenerator(
+                fom = LocalDate.of(2025, 2, 1),
+                tom = LocalDate.of(2025, 1, 1),
+            )
+        }
+    }
+
+    private fun sammenlignPerioder(
+        forventedePerioder: List<ForventetPeriode>,
+        generertePerioder: List<Pair<LocalDate, LocalDate>>,
+    ) {
+        forventedePerioder.forEachIndexed { i, forventetPeriode ->
+            tellAntallDager(
+                generertePerioder[i].first,
+                generertePerioder[i].second,
+            ) `should be equal to` forventetPeriode.antallDager
+            generertePerioder[i].first `should be equal to` forventetPeriode.fom
+            generertePerioder[i].second `should be equal to` forventetPeriode.tom
+        }
+    }
+
+    private fun tellAntallDager(
+        fom: LocalDate,
+        tom: LocalDate,
+    ): Long {
+        return ChronoUnit.DAYS.between(fom, tom) + 1
+    }
+
+    private data class ForventetPeriode(val fomString: String, val tomString: String, val antallDager: Long) {
+        val fom: LocalDate = LocalDate.parse(fomString)
+        val tom: LocalDate = LocalDate.parse(tomString)
+    }
+}

--- a/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidSoknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidSoknadServiceTest.kt
@@ -10,9 +10,9 @@ import java.time.temporal.ChronoUnit
 class FriskTilArbeidSoknadServiceTest {
     @Test
     fun `Generer perioder for en måned med default periodelengde`() {
-        defaultSoknadPeriodeGenerator(
-            fom = LocalDate.of(2025, 1, 1),
-            tom = LocalDate.of(2025, 1, 31),
+        defaultPeriodeGenerator(
+            periodeStart = LocalDate.of(2025, 1, 1),
+            periodeSlutt = LocalDate.of(2025, 1, 31),
         ).also { perioder ->
             assertEquals(3, perioder.size)
 
@@ -28,9 +28,9 @@ class FriskTilArbeidSoknadServiceTest {
 
     @Test
     fun `Generer perioder for en måned med angitt periodelengde`() {
-        defaultSoknadPeriodeGenerator(
-            fom = LocalDate.of(2025, 1, 1),
-            tom = LocalDate.of(2025, 1, 31),
+        defaultPeriodeGenerator(
+            periodeStart = LocalDate.of(2025, 1, 1),
+            periodeSlutt = LocalDate.of(2025, 1, 31),
             periodeLengde = 7,
         ).also {
             assertEquals(5, it.size)
@@ -49,9 +49,9 @@ class FriskTilArbeidSoknadServiceTest {
 
     @Test
     fun `Generer perioder for en enkelt dag`() {
-        defaultSoknadPeriodeGenerator(
-            fom = LocalDate.of(2025, 1, 1),
-            tom = LocalDate.of(2025, 1, 1),
+        defaultPeriodeGenerator(
+            periodeStart = LocalDate.of(2025, 1, 1),
+            periodeSlutt = LocalDate.of(2025, 1, 1),
         ).also { perioder ->
             assertEquals(1, perioder.size)
 
@@ -67,9 +67,9 @@ class FriskTilArbeidSoknadServiceTest {
     @Test
     fun `Generering av perioder feiler når tom er før tom`() {
         assertThrows<IllegalArgumentException> {
-            defaultSoknadPeriodeGenerator(
-                fom = LocalDate.of(2025, 2, 1),
-                tom = LocalDate.of(2025, 1, 1),
+            defaultPeriodeGenerator(
+                periodeStart = LocalDate.of(2025, 2, 1),
+                periodeSlutt = LocalDate.of(2025, 1, 1),
             )
         }
     }

--- a/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidTestUtils.kt
+++ b/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidTestUtils.kt
@@ -9,15 +9,24 @@ internal fun String.asProducerRecordKey(): String = UUID.nameUUIDFromBytes(this.
 internal fun lagFriskTilArbeidVedtakStatus(
     fnr: String,
     status: Status,
-    vedtaksperiode: Pair<LocalDate, LocalDate>? = LocalDate.now() to LocalDate.now(),
+    vedtaksperiode: Vedtaksperiode =
+        Vedtaksperiode(
+            periodeStart = LocalDate.now(),
+            periodeSlutt = LocalDate.now().plusDays(13),
+        ),
 ): FriskTilArbeidVedtakStatus =
     FriskTilArbeidVedtakStatus(
         uuid = UUID.randomUUID().toString(),
         personident = fnr,
         begrunnelse = "Begrunnelse",
-        fom = vedtaksperiode!!.first,
-        tom = vedtaksperiode.second,
+        fom = vedtaksperiode.periodeStart,
+        tom = vedtaksperiode.periodeSlutt,
         status = status,
         statusAt = OffsetDateTime.now(),
         statusBy = "Test",
     )
+
+internal data class Vedtaksperiode(
+    val periodeStart: LocalDate,
+    val periodeSlutt: LocalDate,
+)

--- a/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidTestUtils.kt
+++ b/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidTestUtils.kt
@@ -9,13 +9,14 @@ internal fun String.asProducerRecordKey(): String = UUID.nameUUIDFromBytes(this.
 internal fun lagFriskTilArbeidVedtakStatus(
     fnr: String,
     status: Status,
+    vedtaksperiode: Pair<LocalDate, LocalDate>? = LocalDate.now() to LocalDate.now(),
 ): FriskTilArbeidVedtakStatus =
     FriskTilArbeidVedtakStatus(
         uuid = UUID.randomUUID().toString(),
         personident = fnr,
         begrunnelse = "Begrunnelse",
-        fom = LocalDate.now(),
-        tom = LocalDate.now(),
+        fom = vedtaksperiode!!.first,
+        tom = vedtaksperiode.second,
         status = status,
         statusAt = OffsetDateTime.now(),
         statusBy = "Test",


### PR DESCRIPTION
- **Splitt FriskTilArbeid perioder i søknader**
- **Bruk defaultPeriodeGenerator som default-verdi**
- **Bruk Vedtaksperiode i stedet for Pair**
- **Test at søknader er opprettet**
