### PR TITLE
Kast exception når FriskTilArbeid-perioder overlapper

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/config/EnvironmentToggles.kt
+++ b/src/main/kotlin/no/nav/helse/flex/config/EnvironmentToggles.kt
@@ -17,4 +17,6 @@ class EnvironmentToggles(
     fun isProductionOrQ() = isProduction() || isQ()
 
     fun isReadOnly() = "READONLY" == skrivemodus
+
+    fun environment(): String = fasitEnvironmentName
 }

--- a/src/main/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidConsumer.kt
+++ b/src/main/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidConsumer.kt
@@ -1,6 +1,7 @@
 package no.nav.helse.flex.frisktilarbeid
 
 import com.fasterxml.jackson.core.JacksonException
+import no.nav.helse.flex.config.EnvironmentToggles
 import no.nav.helse.flex.kafka.FRISKTILARBEID_TOPIC
 import no.nav.helse.flex.logger
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component
 @Component
 class FriskTilArbeidConsumer(
     private val friskTilArbeidService: FriskTilArbeidService,
+    private val environmentToggles: EnvironmentToggles,
 ) {
     val log = logger()
 
@@ -40,8 +42,16 @@ class FriskTilArbeidConsumer(
             log.error("Klarte ikke å deserialisere FriskTilArbeidVedtakStatus", e)
             throw e
         } catch (e: Exception) {
-            log.error("Feilet ved mottak av FriskTilArbeidVedtakStatus", e)
-            throw e
+            if (environmentToggles.isNotProduction()) {
+                log.error(
+                    "Feilet ved mottak av FriskTilArbeidVedtakStatus men ACKer Kafka-melding siden vi er i Dev.",
+                    e,
+                )
+                acknowledgment.acknowledge()
+            } else {
+                log.error("Feilet ved mottak av FriskTilArbeidVedtakStatus", e)
+                throw e
+            }
         }
     }
 }

--- a/src/main/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidConsumer.kt
+++ b/src/main/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidConsumer.kt
@@ -1,6 +1,5 @@
 package no.nav.helse.flex.frisktilarbeid
 
-import com.fasterxml.jackson.core.JacksonException
 import no.nav.helse.flex.config.EnvironmentToggles
 import no.nav.helse.flex.kafka.FRISKTILARBEID_TOPIC
 import no.nav.helse.flex.logger
@@ -38,18 +37,16 @@ class FriskTilArbeidConsumer(
                 ),
             )
             acknowledgment.acknowledge()
-        } catch (e: JacksonException) {
-            log.error("Klarte ikke å deserialisere FriskTilArbeidVedtakStatus", e)
-            throw e
         } catch (e: Exception) {
             if (environmentToggles.isNotProduction()) {
                 log.error(
-                    "Feilet ved mottak av FriskTilArbeidVedtakStatus men ACKer Kafka-melding siden vi er i Dev.",
+                    "Feilet ved mottak av FriskTilArbeidVedtakStatus men Ack-er melding siden " +
+                        "environment er ${environmentToggles.environment()}.",
                     e,
                 )
                 acknowledgment.acknowledge()
             } else {
-                log.error("Feilet ved mottak av FriskTilArbeidVedtakStatus", e)
+                log.error("Feilet ved mottak av FriskTilArbeidVedtakStatus.", e)
                 throw e
             }
         }

--- a/src/main/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidRepository.kt
+++ b/src/main/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidRepository.kt
@@ -26,6 +26,8 @@ interface FriskTilArbeidRepository : CrudRepository<FriskTilArbeidVedtakDbRecord
     @Modifying
     @Query("DELETE FROM frisk_til_arbeid_vedtak WHERE fnr = :fnr")
     fun deleteByFnr(fnr: String): Long
+
+    fun findByFnr(fnr: String): List<FriskTilArbeidVedtakDbRecord>
 }
 
 @Table("frisk_til_arbeid_vedtak")

--- a/src/main/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidService.kt
@@ -22,11 +22,11 @@ class FriskTilArbeidService(
         if (friskTilArbeidVedtakStatus.status == Status.FATTET) {
             val eksisterendeVedtak = friskTilArbeidRepository.findByFnr(friskTilArbeidVedtakStatus.personident)
 
-            eksisterendeVedtak.find { vedtakOverlapper(it, friskTilArbeidVedtakStatus) }?.also {
+            eksisterendeVedtak.firstOrNull { vedtakOverlapper(it, friskTilArbeidVedtakStatus) }?.apply {
                 val feilmelding =
                     "Vedtak med key: ${kafkaMelding.key} og " +
                         "periode: [${friskTilArbeidVedtakStatus.fom} - ${friskTilArbeidVedtakStatus.tom}] " +
-                        "overlapper med vedtak med periode: [${it.fom} - ${it.tom}]."
+                        "overlapper med vedtak med periode: [$fom - $tom]."
                 log.error(feilmelding)
                 throw FriskTilArbeidVedtakStatusException(feilmelding)
             }

--- a/src/main/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidTestDataConsumer.kt
+++ b/src/main/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidTestDataConsumer.kt
@@ -32,7 +32,7 @@ class FriskTilArbeidTestDataConsumer(
                 ),
             )
         } catch (e: Exception) {
-            log.error("Feilet ved mottak av FriskTilArbeidVedtakStatus", e)
+            log.error("Feilet ved mottak av FriskTilArbeidVedtakStatus.", e)
         } finally {
             acknowledgment.acknowledge()
         }

--- a/src/test/kotlin/no/nav/helse/flex/fakes/OppsamlingAvRepositoryFakes.kt
+++ b/src/test/kotlin/no/nav/helse/flex/fakes/OppsamlingAvRepositoryFakes.kt
@@ -315,6 +315,10 @@ class FriskTilArbeidRepositoryFake : FriskTilArbeidRepository {
         TODO("Not yet implemented")
     }
 
+    override fun findByFnr(fnr: String): List<FriskTilArbeidVedtakDbRecord> {
+        TODO("Not yet implemented")
+    }
+
     override fun <S : FriskTilArbeidVedtakDbRecord?> save(entity: S & Any): S & Any {
         TODO("Not yet implemented")
     }

--- a/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidServiceTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidServiceTest.kt
@@ -5,6 +5,7 @@ import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldHaveSize
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.test.context.SpringBootTest
@@ -30,11 +31,10 @@ class FriskTilArbeidServiceTest {
     }
 
     private val fnr = "11111111111"
+    private val key = fnr.asProducerRecordKey()
 
     @Test
     fun `Lagrer vedtak med status FATTET`() {
-        val key = fnr.asProducerRecordKey()
-
         friskTilArbeidService.lagreFriskTilArbeidVedtakStatus(
             FriskTilArbeidVedtakStatusKafkaMelding(
                 key = key,
@@ -47,8 +47,6 @@ class FriskTilArbeidServiceTest {
 
     @Test
     fun `Lagrer ikke vedtak med status FERDIG_BEHANDLET`() {
-        val key = fnr.asProducerRecordKey()
-
         friskTilArbeidService.lagreFriskTilArbeidVedtakStatus(
             FriskTilArbeidVedtakStatusKafkaMelding(
                 key = key,
@@ -57,6 +55,154 @@ class FriskTilArbeidServiceTest {
         )
 
         fakeFriskTilArbeidRepository.findAll().toList() shouldHaveSize 0
+    }
+
+    @Test
+    fun `Lagrer to perioder som ikke overlapper`() {
+        friskTilArbeidService.lagreFriskTilArbeidVedtakStatus(
+            FriskTilArbeidVedtakStatusKafkaMelding(
+                key = key,
+                friskTilArbeidVedtakStatus =
+                    lagFriskTilArbeidVedtakStatus(
+                        fnr,
+                        Status.FATTET,
+                        Vedtaksperiode(
+                            periodeStart = LocalDate.of(2024, 1, 1),
+                            periodeSlutt = LocalDate.of(2024, 1, 7),
+                        ),
+                    ),
+            ),
+        )
+        friskTilArbeidService.lagreFriskTilArbeidVedtakStatus(
+            FriskTilArbeidVedtakStatusKafkaMelding(
+                key = key,
+                friskTilArbeidVedtakStatus =
+                    lagFriskTilArbeidVedtakStatus(
+                        fnr,
+                        Status.FATTET,
+                        Vedtaksperiode(
+                            periodeStart = LocalDate.of(2024, 1, 8),
+                            periodeSlutt = LocalDate.of(2024, 1, 15),
+                        ),
+                    ),
+            ),
+        )
+        fakeFriskTilArbeidRepository.findAll().toList() shouldHaveSize 2
+    }
+
+    @Test
+    fun `Lagrer to overlappende perioder for to forskjellige brukere`() {
+        lagFriskTilArbeidVedtakStatus(
+            Vedtaksperiode(
+                periodeStart = LocalDate.of(2024, 1, 1),
+                periodeSlutt = LocalDate.of(2024, 1, 7),
+            ),
+        )
+
+        lagFriskTilArbeidVedtakStatus(
+            Vedtaksperiode(
+                periodeStart = LocalDate.of(2024, 1, 5),
+                periodeSlutt = LocalDate.of(2024, 1, 13),
+            ),
+            personident = "22222222222",
+        )
+
+        fakeFriskTilArbeidRepository.findAll().toList() shouldHaveSize 2
+    }
+
+    @Test
+    fun `Feiler ved lagring av to vedtak med samme fom og tom`() {
+        lagFriskTilArbeidVedtakStatus(
+            Vedtaksperiode(
+                periodeStart = LocalDate.of(2024, 1, 1),
+                periodeSlutt = LocalDate.of(2024, 1, 7),
+            ),
+        )
+
+        assertThrows<FriskTilArbeidVedtakStatusException> {
+            lagFriskTilArbeidVedtakStatus(
+                Vedtaksperiode(
+                    periodeStart = LocalDate.of(2024, 1, 1),
+                    periodeSlutt = LocalDate.of(2024, 1, 7),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `Feiler ved lagring av nytt vedtak med fom før eksisterende vedtaks tom`() {
+        lagFriskTilArbeidVedtakStatus(
+            Vedtaksperiode(
+                periodeStart = LocalDate.of(2024, 1, 1),
+                periodeSlutt = LocalDate.of(2024, 1, 7),
+            ),
+        )
+
+        assertThrows<FriskTilArbeidVedtakStatusException> {
+            lagFriskTilArbeidVedtakStatus(
+                Vedtaksperiode(
+                    periodeStart = LocalDate.of(2024, 1, 5),
+                    periodeSlutt = LocalDate.of(2024, 1, 13),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `Feiler ved lagring av nytt vedtak med tom etter eksisterende vedtaks fom`() {
+        lagFriskTilArbeidVedtakStatus(
+            Vedtaksperiode(
+                periodeStart = LocalDate.of(2024, 1, 5),
+                periodeSlutt = LocalDate.of(2024, 1, 13),
+            ),
+        )
+
+        assertThrows<FriskTilArbeidVedtakStatusException> {
+            lagFriskTilArbeidVedtakStatus(
+                Vedtaksperiode(
+                    periodeStart = LocalDate.of(2024, 1, 1),
+                    periodeSlutt = LocalDate.of(2024, 1, 7),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `Feiler ved lagring av nytt vedtak med fom lik eksisterende vedtaks tom`() {
+        lagFriskTilArbeidVedtakStatus(
+            Vedtaksperiode(
+                periodeStart = LocalDate.of(2024, 1, 1),
+                periodeSlutt = LocalDate.of(2024, 1, 7),
+            ),
+        )
+
+        assertThrows<FriskTilArbeidVedtakStatusException> {
+            lagFriskTilArbeidVedtakStatus(
+                Vedtaksperiode(
+                    periodeStart = LocalDate.of(2024, 1, 7),
+                    periodeSlutt = LocalDate.of(2024, 1, 14),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `Feiler ved lagring av nytt vedtak med tom lik eksisterende vedtaks fom`() {
+        lagFriskTilArbeidVedtakStatus(
+            Vedtaksperiode(
+                periodeStart = LocalDate.of(2024, 1, 7),
+                periodeSlutt = LocalDate.of(2024, 1, 14),
+            ),
+        )
+
+        assertThrows<FriskTilArbeidVedtakStatusException> {
+            lagFriskTilArbeidVedtakStatus(
+                Vedtaksperiode(
+                    periodeStart = LocalDate.of(2024, 1, 1),
+                    periodeSlutt = LocalDate.of(2024, 1, 7),
+                ),
+            )
+        }
     }
 
     @Test
@@ -76,15 +222,28 @@ class FriskTilArbeidServiceTest {
         )
 
         friskTilArbeidService.behandleFriskTilArbeidVedtakStatus(1)
-        val all = fakeFriskTilArbeidRepository.findAll().toList()
-
-        val en = all.find { it.fnr == "11111111111" }
-        val to = all.find { it.fnr == "22222222222" }
 
         fakeFriskTilArbeidRepository.findAll().toList().also {
             it.find { it.fnr == "11111111111" }?.behandletStatus `should be equal to` BehandletStatus.BEHANDLET
             it.find { it.fnr == "22222222222" }?.behandletStatus `should be equal to` BehandletStatus.NY
         }
+    }
+
+    private fun lagFriskTilArbeidVedtakStatus(
+        vedtaksperiode: Vedtaksperiode,
+        personident: String = fnr,
+    ) {
+        friskTilArbeidService.lagreFriskTilArbeidVedtakStatus(
+            FriskTilArbeidVedtakStatusKafkaMelding(
+                key = personident.asProducerRecordKey(),
+                friskTilArbeidVedtakStatus =
+                    lagFriskTilArbeidVedtakStatus(
+                        personident,
+                        Status.FATTET,
+                        vedtaksperiode,
+                    ),
+            ),
+        )
     }
 }
 
@@ -134,5 +293,7 @@ class FriskTilArbeidTestConfig {
             toDelete.forEach { delete(it) }
             return toDelete.size.toLong()
         }
+
+        override fun findByFnr(fnr: String): List<FriskTilArbeidVedtakDbRecord> = findAll().filter { it.fnr == fnr }
     }
 }

--- a/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidServiceTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/frisktilarbeid/FriskTilArbeidServiceTest.kt
@@ -59,34 +59,20 @@ class FriskTilArbeidServiceTest {
 
     @Test
     fun `Lagrer to perioder som ikke overlapper`() {
-        friskTilArbeidService.lagreFriskTilArbeidVedtakStatus(
-            FriskTilArbeidVedtakStatusKafkaMelding(
-                key = key,
-                friskTilArbeidVedtakStatus =
-                    lagFriskTilArbeidVedtakStatus(
-                        fnr,
-                        Status.FATTET,
-                        Vedtaksperiode(
-                            periodeStart = LocalDate.of(2024, 1, 1),
-                            periodeSlutt = LocalDate.of(2024, 1, 7),
-                        ),
-                    ),
+        lagFriskTilArbeidVedtakStatus(
+            Vedtaksperiode(
+                periodeStart = LocalDate.of(2024, 1, 1),
+                periodeSlutt = LocalDate.of(2024, 1, 7),
             ),
         )
-        friskTilArbeidService.lagreFriskTilArbeidVedtakStatus(
-            FriskTilArbeidVedtakStatusKafkaMelding(
-                key = key,
-                friskTilArbeidVedtakStatus =
-                    lagFriskTilArbeidVedtakStatus(
-                        fnr,
-                        Status.FATTET,
-                        Vedtaksperiode(
-                            periodeStart = LocalDate.of(2024, 1, 8),
-                            periodeSlutt = LocalDate.of(2024, 1, 15),
-                        ),
-                    ),
+
+        lagFriskTilArbeidVedtakStatus(
+            Vedtaksperiode(
+                periodeStart = LocalDate.of(2024, 1, 8),
+                periodeSlutt = LocalDate.of(2024, 1, 15),
             ),
         )
+
         fakeFriskTilArbeidRepository.findAll().toList() shouldHaveSize 2
     }
 


### PR DESCRIPTION
Skjer nok ikke all verdens ofte i Prod, men greit å ha i Dev, så vi ikke ender opp med testbruker med masse overlappende søknader.