### PR TITLE
Fjern tilgang til teamsykmelding:dinesykmeldte-backend

### DIFF
--- a/nais/topics/sykepengesoknad-topic.yaml
+++ b/nais/topics/sykepengesoknad-topic.yaml
@@ -52,9 +52,6 @@ spec:
     - team: team-esyfo
       application: dinesykmeldte-backend
       access: read
-    - team: teamsykmelding
-      application: dinesykmeldte-backend
-      access: read
     - team: medlemskap
       application: medlemskap-sykepenger-listener
       access: read


### PR DESCRIPTION
Er tatt over av team-esyfo:dinesykmeldte-backend
