### PR TITLE
bytter ingress for inntektskomponenten til ikomp i gcp

### DIFF
--- a/nais/app/dev.yaml
+++ b/nais/app/dev.yaml
@@ -12,6 +12,7 @@ replicas_max: 2
 external-host:
   - pdl-api.dev-fss-pub.nais.io
   - ereg-services.dev-fss-pub.nais.io
+  - team-inntekt-proxy.dev-fss-pub.nais.io
   - ikomp-q1.intern.dev.nav.no
   - flex-unleash-api.nav.cloud.nais.io
   - aareg-services-q1.dev-fss-pub.nais.io
@@ -41,7 +42,7 @@ env:
   MEDLEMSKAP_VURDERING_AAD_CLIENT_ID: dev-gcp.medlemskap.medlemskap-sykepenger-listener
   INNTEKTSKOMPONENTEN_URL: https://ikomp-q1.dev-fss-pub.nais.io/rs
   INNTEKTSKOMPONENTEN_AAD_CLIENT_ID: dev-fss.team-inntekt.ikomp-q1
-  SIGRUN_URL: https://sigrun-q1.dev.nav.no
+  SIGRUN_URL: https://team-inntekt-proxy.dev-fss-pub.nais.io/proxy/sigrun-q1
   SIGRUN_AAD_CLIENT_ID: dev-fss.team-inntekt.sigrun-q1
   INNSENDING_API_TOKENX_CLIENT_ID: dev-gcp:team-soknad:innsending-api
   INNSENDING_API_URL: http://innsending-api.team-soknad

--- a/nais/app/dev.yaml
+++ b/nais/app/dev.yaml
@@ -12,7 +12,7 @@ replicas_max: 2
 external-host:
   - pdl-api.dev-fss-pub.nais.io
   - ereg-services.dev-fss-pub.nais.io
-  - team-inntekt-proxy.dev-fss-pub.nais.io
+  - ikomp-q1.intern.dev.nav.no
   - flex-unleash-api.nav.cloud.nais.io
   - aareg-services-q1.dev-fss-pub.nais.io
   - g.nav.no
@@ -39,9 +39,9 @@ env:
   YRKESSKADE_AAD_CLIENT_ID: dev-gcp.yrkesskade.yrkesskade-saker
   MEDLEMSKAP_VURDERING_URL: http://medlemskap-sykepenger-listener.medlemskap
   MEDLEMSKAP_VURDERING_AAD_CLIENT_ID: dev-gcp.medlemskap.medlemskap-sykepenger-listener
-  INNTEKTSKOMPONENTEN_URL: https://team-inntekt-proxy.dev-fss-pub.nais.io/proxy/inntektskomponenten-q1/rs
-  INNTEKTSKOMPONENTEN_AAD_CLIENT_ID: dev-fss.team-inntekt.inntektskomponenten
-  SIGRUN_URL: https://team-inntekt-proxy.dev-fss-pub.nais.io/proxy/sigrun-q1
+  INNTEKTSKOMPONENTEN_URL: https://ikomp-q1.intern.dev.nav.no/rs
+  INNTEKTSKOMPONENTEN_AAD_CLIENT_ID: dev-gcp.team-inntekt.inntektskomponenten
+  SIGRUN_URL: https://sigrun-q1.dev.nav.no
   SIGRUN_AAD_CLIENT_ID: dev-fss.team-inntekt.sigrun-q1
   INNSENDING_API_TOKENX_CLIENT_ID: dev-gcp:team-soknad:innsending-api
   INNSENDING_API_URL: http://innsending-api.team-soknad

--- a/nais/app/dev.yaml
+++ b/nais/app/dev.yaml
@@ -39,8 +39,8 @@ env:
   YRKESSKADE_AAD_CLIENT_ID: dev-gcp.yrkesskade.yrkesskade-saker
   MEDLEMSKAP_VURDERING_URL: http://medlemskap-sykepenger-listener.medlemskap
   MEDLEMSKAP_VURDERING_AAD_CLIENT_ID: dev-gcp.medlemskap.medlemskap-sykepenger-listener
-  INNTEKTSKOMPONENTEN_URL: https://ikomp-q1.intern.dev.nav.no/rs
-  INNTEKTSKOMPONENTEN_AAD_CLIENT_ID: dev-gcp.team-inntekt.inntektskomponenten
+  INNTEKTSKOMPONENTEN_URL: https://ikomp-q1.dev-fss-pub.nais.io/rs
+  INNTEKTSKOMPONENTEN_AAD_CLIENT_ID: dev-fss.team-inntekt.ikomp-q1
   SIGRUN_URL: https://sigrun-q1.dev.nav.no
   SIGRUN_AAD_CLIENT_ID: dev-fss.team-inntekt.sigrun-q1
   INNSENDING_API_TOKENX_CLIENT_ID: dev-gcp:team-soknad:innsending-api

--- a/nais/app/prod.yaml
+++ b/nais/app/prod.yaml
@@ -12,7 +12,7 @@ replicas_max: 5
 external-host:
   - pdl-api.prod-fss-pub.nais.io
   - ereg-services.prod-fss-pub.nais.io
-  - team-inntekt-proxy.prod-fss-pub.nais.io
+  - https://ikomp.intern.nav.no
   - flex-unleash-api.nav.cloud.nais.io
   - aareg-services.prod-fss-pub.nais.io
   - g.nav.no
@@ -37,9 +37,9 @@ env:
   YRKESSKADE_AAD_CLIENT_ID: prod-gcp.yrkesskade.yrkesskade-saker
   MEDLEMSKAP_VURDERING_URL: http://medlemskap-sykepenger-listener.medlemskap
   MEDLEMSKAP_VURDERING_AAD_CLIENT_ID: prod-gcp.medlemskap.medlemskap-sykepenger-listener
-  INNTEKTSKOMPONENTEN_URL: https://team-inntekt-proxy.prod-fss-pub.nais.io/proxy/inntektskomponenten/rs
-  INNTEKTSKOMPONENTEN_AAD_CLIENT_ID: prod-fss.team-inntekt.inntektskomponenten
-  SIGRUN_URL: https://team-inntekt-proxy.prod-fss-pub.nais.io/proxy/sigrun
+  INNTEKTSKOMPONENTEN_URL: https://ikomp.intern.nav.no/rs
+  INNTEKTSKOMPONENTEN_AAD_CLIENT_ID: prod-gcp.team-inntekt.inntektskomponenten
+  SIGRUN_URL: https://ikomp.intern.nav.no/sigrun
   SIGRUN_AAD_CLIENT_ID: prod-fss.team-inntekt.sigrun
   INNSENDING_API_TOKENX_CLIENT_ID: prod-gcp:team-soknad:innsending-api
   INNSENDING_API_URL: http://innsending-api.team-soknad

--- a/nais/app/prod.yaml
+++ b/nais/app/prod.yaml
@@ -12,6 +12,7 @@ replicas_max: 5
 external-host:
   - pdl-api.prod-fss-pub.nais.io
   - ereg-services.prod-fss-pub.nais.io
+  - team-inntekt-proxy.dev-fss-pub.nais.io
   - https://ikomp.intern.nav.no
   - flex-unleash-api.nav.cloud.nais.io
   - aareg-services.prod-fss-pub.nais.io
@@ -39,7 +40,7 @@ env:
   MEDLEMSKAP_VURDERING_AAD_CLIENT_ID: prod-gcp.medlemskap.medlemskap-sykepenger-listener
   INNTEKTSKOMPONENTEN_URL: https://ikomp.prod-fss-pub.nais.io/rs
   INNTEKTSKOMPONENTEN_AAD_CLIENT_ID: prod-fss.team-inntekt.ikomp
-  SIGRUN_URL: https://ikomp.intern.nav.no/sigrun
+  SIGRUN_URL: https://team-inntekt-proxy.prod-fss-pub.nais.io/proxy/sigrun
   SIGRUN_AAD_CLIENT_ID: prod-fss.team-inntekt.sigrun
   INNSENDING_API_TOKENX_CLIENT_ID: prod-gcp:team-soknad:innsending-api
   INNSENDING_API_URL: http://innsending-api.team-soknad

--- a/nais/app/prod.yaml
+++ b/nais/app/prod.yaml
@@ -37,8 +37,8 @@ env:
   YRKESSKADE_AAD_CLIENT_ID: prod-gcp.yrkesskade.yrkesskade-saker
   MEDLEMSKAP_VURDERING_URL: http://medlemskap-sykepenger-listener.medlemskap
   MEDLEMSKAP_VURDERING_AAD_CLIENT_ID: prod-gcp.medlemskap.medlemskap-sykepenger-listener
-  INNTEKTSKOMPONENTEN_URL: https://ikomp.intern.nav.no/rs
-  INNTEKTSKOMPONENTEN_AAD_CLIENT_ID: prod-gcp.team-inntekt.inntektskomponenten
+  INNTEKTSKOMPONENTEN_URL: https://ikomp.prod-fss-pub.nais.io/rs
+  INNTEKTSKOMPONENTEN_AAD_CLIENT_ID: prod-fss.team-inntekt.ikomp
   SIGRUN_URL: https://ikomp.intern.nav.no/sigrun
   SIGRUN_AAD_CLIENT_ID: prod-fss.team-inntekt.sigrun
   INNSENDING_API_TOKENX_CLIENT_ID: prod-gcp:team-soknad:innsending-api


### PR DESCRIPTION
Inntektskomponenten bruker ikke lenger proxy, så endrer url for å kalle direkte på den. Sigrun er fortsatt på proxy, så beholder config for team-inntekt-proxy