### PR TITLE
øker minimumInSyncReplicas til 2

### DIFF
--- a/nais/topics/sykepengesoknad-topic.yaml
+++ b/nais/topics/sykepengesoknad-topic.yaml
@@ -12,7 +12,7 @@ spec:
   pool: {{kafkaPool}}
   config:
     cleanupPolicy: delete
-    minimumInSyncReplicas: 1
+    minimumInSyncReplicas: 2
     partitions: 3
     replication: 3
     retentionBytes: -1      # Messages will never get deleted because of disk space


### PR DESCRIPTION
**Begrunnelse for å øke minimumInSyncReplicas til 2 og ingen andre endringer nødvendig:**

**Ansvarsfraskrivelse: Denne begrunnelsen ble generert av en AI-assistent.**

"Det foreslås å øke `minimumInSyncReplicas` til 2 for å forbedre datadynamikken med `acks=all`. Gitt vår eksisterende `replication: 3`, kan denne endringen gjøres uten å kreve ytterligere strukturelle endringer i topic-en, da vi allerede har tilstrekkelig med replikaer til å tåle feil på én replika samtidig som vi opprettholder det nødvendige in-sync settet."
