### PR TITLE
Bruk felles RETRY_ATTEMPTS

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/client/bregDirect/EnhetsregisterClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/client/bregDirect/EnhetsregisterClient.kt
@@ -15,7 +15,7 @@ class EnhetsregisterClient(
 ) {
     @Retryable(
         include = [HttpServerErrorException::class],
-        maxAttemptsExpression = "\${BRREG_RETRY_ATTEMPTS:3}",
+        maxAttemptsExpression = "\${CLIENT_RETRY_ATTEMPTS:3}",
     )
     fun erBarnepasser(organisasjonsnummer: String): Boolean {
         val response =

--- a/src/main/kotlin/no/nav/helse/flex/client/brreg/BrregClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/client/brreg/BrregClient.kt
@@ -11,7 +11,7 @@ import org.springframework.web.client.toEntity
 class BrregClient(
     private val brregRestClient: RestClient,
 ) {
-    @Retryable(include = [HttpServerErrorException::class], maxAttemptsExpression = "\${BRREG_RETRY_ATTEMPTS:3}")
+    @Retryable(include = [HttpServerErrorException::class], maxAttemptsExpression = "\${CLIENT_RETRY_ATTEMPTS:3}")
     fun hentRoller(
         fnr: String,
         rolleTyper: List<Rolletype>? = null,

--- a/src/main/kotlin/no/nav/helse/flex/client/flexsyketilfelle/FlexSyketilfelleClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/client/flexsyketilfelle/FlexSyketilfelleClient.kt
@@ -104,7 +104,7 @@ class FlexSyketilfelleClient(
             ?: throw RuntimeException("Ingen data returnert fra flex-syketilfelle ved kall til erUtenforVentetid")
     }
 
-    @Retryable(include = [HttpServerErrorException::class], maxAttemptsExpression = "\${VENTETID_RETRY_ATTEMPTS:3}")
+    @Retryable(include = [HttpServerErrorException::class], maxAttemptsExpression = "\${CLIENT_RETRY_ATTEMPTS:3}")
     fun hentVentetid(
         identer: FolkeregisterIdenter,
         sykmeldingId: String,

--- a/src/main/kotlin/no/nav/helse/flex/client/grunnbeloep/GrunnbeloepClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/client/grunnbeloep/GrunnbeloepClient.kt
@@ -19,7 +19,7 @@ class GrunnbeloepClient(
 ) {
     @Retryable(
         value = [HttpServerErrorException::class, HttpClientErrorException::class],
-        maxAttemptsExpression = $$"${GRUNNBELOEP_RETRY_ATTEMPTS:3}",
+        maxAttemptsExpression = $$"${CLIENT_RETRY_ATTEMPTS:3}",
         backoff = Backoff(delay = 1000),
     )
     fun hentGrunnbeloepHistorikk(hentForDato: LocalDate): List<GrunnbeloepResponse> =

--- a/src/test/kotlin/no/nav/helse/flex/client/brreg/BrregClientTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/client/brreg/BrregClientTest.kt
@@ -13,7 +13,7 @@ import org.springframework.test.context.TestPropertySource
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.HttpServerErrorException
 
-@TestPropertySource(properties = ["BRREG_RETRY_ATTEMPTS=1"])
+@TestPropertySource(properties = ["CLIENT_RETRY_ATTEMPTS=1"])
 class BrregClientTest : FellesTestOppsett() {
     @Autowired
     private lateinit var brregClient: BrregClient

--- a/src/test/kotlin/no/nav/helse/flex/service/GrunnbeloepServiceTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/service/GrunnbeloepServiceTest.kt
@@ -17,7 +17,7 @@ import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.HttpServerErrorException
 import java.time.LocalDate
 
-@TestPropertySource(properties = ["GRUNNBELOEP_RETRY_ATTEMPTS=1"])
+@TestPropertySource(properties = ["CLIENT_RETRY_ATTEMPTS=1"])
 class GrunnbeloepServiceTest : FellesTestOppsett() {
     @Autowired
     private lateinit var cacheManager: CacheManager

--- a/src/test/kotlin/no/nav/helse/flex/service/SelvstendigNaringsdrivendeInfoServiceTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/service/SelvstendigNaringsdrivendeInfoServiceTest.kt
@@ -28,7 +28,7 @@ import java.time.LocalDate
 private const val ORGNAVN = "orgnavn"
 private const val ORGNUMMER = "orgnummer"
 
-@TestPropertySource(properties = ["BRREG_RETRY_ATTEMPTS=1", "VENTETID_RETRY_ATTEMPTS=1"])
+@TestPropertySource(properties = ["CLIENT_RETRY_ATTEMPTS=1"])
 class SelvstendigNaringsdrivendeInfoServiceTest : FakesTestOppsett() {
     @Autowired
     @Qualifier("brregMockWebServer")


### PR DESCRIPTION
Kan være felles da vi defaulter til 3 retries, og
det ellers brukes kun til å forhindre at det gjøres retries i tester.
