### PR TITLE
Oppretter ikke søknad for sykmelding som har blitt brukt til en arbeidstakersøknad

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/domain/sykmelding/SykmeldingTilSoknadOpprettelse.kt
+++ b/src/main/kotlin/no/nav/helse/flex/domain/sykmelding/SykmeldingTilSoknadOpprettelse.kt
@@ -28,6 +28,7 @@ data class SykmeldingTilSoknadOpprettelse(
     val arbeidsgiverOrgnummer: String?,
     val arbeidsgiverNavn: String?,
     val tidligereArbeidsgiverOrgnummer: String?,
+    val erPapirsykmelding: Boolean,
 )
 
 data class Sykmeldingsperiode(
@@ -87,4 +88,5 @@ fun SykmeldingKafkaMessageDTO.tilSykmeldingTilSoknadOpprettelse() =
                 ?.orgNavn
                 ?.prettyOrgnavn(),
         tidligereArbeidsgiverOrgnummer = this.event.tidligereArbeidsgiver?.orgnummer,
+        erPapirsykmelding = this.sykmelding.papirsykmelding,
     )

--- a/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/OpprettSoknadService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/OpprettSoknadService.kt
@@ -139,10 +139,16 @@ class OpprettSoknadService(
 
         if (aktiveEksisterendeSoknaderForSm.isNotEmpty()) {
             if (sykmeldingErBruktTilArbeidstaker(aktiveEksisterendeSoknaderForSm)) {
-                log.info(
-                    "Oppretter ikke søknader for sykmelding: ${sykmeldingTilSoknadOpprettelse.sykmeldingId} siden sykmeldingen allerede er brukt til arbeidstaker.",
-                )
-                return emptyList()
+                if (sykmeldingTilSoknadOpprettelse.erPapirsykmelding || sykmeldingTilSoknadOpprettelse.erUtlandskSykmelding) {
+                    log.info(
+                        "Sykmeldingen for arbeidstaker kan korrigeres: erPapirSykmelding ${sykmeldingTilSoknadOpprettelse.erPapirsykmelding}, erUtenlandskSykmelding ${sykmeldingTilSoknadOpprettelse.erUtlandskSykmelding}",
+                    )
+                } else {
+                    log.info(
+                        "Oppretter ikke søknader for sykmelding: ${sykmeldingTilSoknadOpprettelse.sykmeldingId} siden sykmeldingen allerede er brukt til arbeidstaker.",
+                    )
+                    return emptyList()
+                }
             }
             val sammenliknbartSettAvNyeSoknader = soknaderTilOppretting.map { it.tilSoknadSammenlikner() }.toHashSet()
             val sammenliknbartSettAvEksisterendeSoknaderForSm =

--- a/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/OpprettSoknadService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/OpprettSoknadService.kt
@@ -134,14 +134,19 @@ class OpprettSoknadService(
                 }.flatten()
 
         val eksisterendeSoknaderForSm = eksisterendeSoknader.filter { it.sykmeldingId == sykmeldingTilSoknadOpprettelse.sykmeldingId }
+        val aktiveEksisterendeSoknaderForSm =
+            eksisterendeSoknaderForSm.filter { it.status !in listOf(Soknadstatus.KORRIGERT, Soknadstatus.UTKAST_TIL_KORRIGERING) }
 
-        if (eksisterendeSoknaderForSm.isNotEmpty()) {
+        if (aktiveEksisterendeSoknaderForSm.isNotEmpty()) {
+            if (sykmeldingErBruktTilArbeidstaker(aktiveEksisterendeSoknaderForSm)) {
+                log.info(
+                    "Oppretter ikke søknader for sykmelding: ${sykmeldingTilSoknadOpprettelse.sykmeldingId} siden sykmeldingen allerede er brukt til arbeidstaker.",
+                )
+                return emptyList()
+            }
             val sammenliknbartSettAvNyeSoknader = soknaderTilOppretting.map { it.tilSoknadSammenlikner() }.toHashSet()
             val sammenliknbartSettAvEksisterendeSoknaderForSm =
-                eksisterendeSoknaderForSm
-                    .filter { it.status !in listOf(Soknadstatus.KORRIGERT, Soknadstatus.UTKAST_TIL_KORRIGERING) }
-                    .map { it.tilSoknadSammenlikner() }
-                    .toHashSet()
+                aktiveEksisterendeSoknaderForSm.map { it.tilSoknadSammenlikner() }.toHashSet()
             if (sammenliknbartSettAvEksisterendeSoknaderForSm == sammenliknbartSettAvNyeSoknader) {
                 log.info(
                     "Oppretter ikke søknader for sykmelding: ${sykmeldingTilSoknadOpprettelse.sykmeldingId} siden eksisterende identiske søknader finnes.",
@@ -207,6 +212,9 @@ class OpprettSoknadService(
         return sykepengesoknad
     }
 }
+
+private fun sykmeldingErBruktTilArbeidstaker(eksisterendeSoknaderForSm: List<Sykepengesoknad>): Boolean =
+    eksisterendeSoknaderForSm.any { it.arbeidssituasjon == ARBEIDSTAKER }
 
 private fun Sykepengesoknad.markerForsteganssoknad(
     eksisterendeSoknader: List<Sykepengesoknad>,

--- a/src/test/kotlin/no/nav/helse/flex/papirsykmelding/AutomatiskPapirsykmeldingOpprydningTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/papirsykmelding/AutomatiskPapirsykmeldingOpprydningTest.kt
@@ -1,32 +1,26 @@
 package no.nav.helse.flex.papirsykmelding
 
-import no.nav.helse.flex.FellesTestOppsett
+import no.nav.helse.flex.*
 import no.nav.helse.flex.controller.domain.sykepengesoknad.RSSoknadstatus
 import no.nav.helse.flex.domain.Arbeidssituasjon
-import no.nav.helse.flex.hentSoknad
-import no.nav.helse.flex.hentSoknaderMetadata
 import no.nav.helse.flex.kafka.consumer.SYKMELDINGSENDT_TOPIC
-import no.nav.helse.flex.mockFlexSyketilfelleArbeidsgiverperiode
-import no.nav.helse.flex.mockFlexSyketilfelleSykeforloep
 import no.nav.helse.flex.sykepengesoknad.kafka.SoknadsstatusDTO.*
-import no.nav.helse.flex.testdata.skapArbeidsgiverSykmelding
-import no.nav.helse.flex.testdata.skapSykmeldingStatusKafkaMessageDTO
+import no.nav.helse.flex.testdata.gradertSykmeldt
+import no.nav.helse.flex.testdata.heltSykmeldt
+import no.nav.helse.flex.testdata.sykmeldingKafkaMessage
 import no.nav.helse.flex.testutil.SoknadBesvarer
-import no.nav.helse.flex.tilSoknader
-import no.nav.helse.flex.ventPåRecords
-import no.nav.syfo.model.sykmelding.model.GradertDTO
-import no.nav.syfo.model.sykmelding.model.PeriodetypeDTO
-import no.nav.syfo.sykmelding.kafka.model.ArbeidsgiverStatusKafkaDTO
-import no.nav.syfo.sykmelding.kafka.model.STATUS_SENDT
+import no.nav.syfo.model.sykmelding.arbeidsgiver.SykmeldingsperiodeAGDTO
 import no.nav.syfo.sykmelding.kafka.model.SykmeldingKafkaMessageDTO
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.MethodOrderer
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestMethodOrder
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldHaveSize
+import org.junit.jupiter.api.*
 import java.time.LocalDate
+import java.util.*
 
+/**
+ * Veiledere endrer på feil i papir og utenlandsk sykmelding
+ */
 @TestMethodOrder(MethodOrderer.MethodName::class)
 class AutomatiskPapirsykmeldingOpprydningTest : FellesTestOppsett() {
     @BeforeEach
@@ -40,46 +34,38 @@ class AutomatiskPapirsykmeldingOpprydningTest : FellesTestOppsett() {
         juridiskVurderingKafkaConsumer.ventPåRecords(3)
     }
 
-    companion object {
-        private val fnr = "12345678900"
-        val sykmeldingStatusKafkaMessageDTO =
-            skapSykmeldingStatusKafkaMessageDTO(
-                fnr = fnr,
-                arbeidssituasjon = Arbeidssituasjon.ARBEIDSTAKER,
-                statusEvent = STATUS_SENDT,
-                arbeidsgiver = ArbeidsgiverStatusKafkaDTO(orgnummer = "123454543", orgNavn = "Gatekjøkkenet"),
-            )
-        val sykmeldingId = sykmeldingStatusKafkaMessageDTO.event.sykmeldingId
-        val sykmelding =
-            skapArbeidsgiverSykmelding(
-                sykmeldingId = sykmeldingId,
-                fom = LocalDate.of(2020, 1, 1),
-                tom = LocalDate.of(2020, 3, 15),
-            )
-    }
+    private val fnr = "12345678900"
+
+    private val sykmeldingId = UUID.randomUUID().toString()
+    private val papirsykmeldingKafkaMessage =
+        sykmeldingKafkaMessage(
+            erPapirsykmelding = true,
+            fnr = fnr,
+            arbeidssituasjon = Arbeidssituasjon.ARBEIDSTAKER,
+            sykmeldingId = sykmeldingId,
+            sykmeldingsperioder =
+                heltSykmeldt(
+                    fom = LocalDate.of(2020, 1, 1),
+                    tom = LocalDate.of(2020, 3, 15),
+                ),
+        )
 
     @Test
-    fun `1 - arbeidstakersøknader opprettes for en lang sykmelding`() {
-        mockFlexSyketilfelleSykeforloep(sykmelding.id)
+    fun `1 - Søknader til arbeidstaker opprettes for en lang papirsykmelding`() {
+        mockFlexSyketilfelleSykeforloep(papirsykmeldingKafkaMessage.sykmelding.id)
 
-        val sykmeldingKafkaMessage =
-            SykmeldingKafkaMessageDTO(
-                sykmelding = sykmelding,
-                event = sykmeldingStatusKafkaMessageDTO.event,
-                kafkaMetadata = sykmeldingStatusKafkaMessageDTO.kafkaMetadata,
-            )
+        behandleSykmeldingOgBestillAktivering.prosesserSykmelding(
+            sykmeldingId = sykmeldingId,
+            sykmeldingKafkaMessage = papirsykmeldingKafkaMessage,
+            topic = SYKMELDINGSENDT_TOPIC,
+        )
 
-        behandleSykmeldingOgBestillAktivering.prosesserSykmelding(sykmeldingId, sykmeldingKafkaMessage, SYKMELDINGSENDT_TOPIC)
+        sykepengesoknadKafkaConsumer.ventPåRecords(antall = 3).tilSoknader().let { sykepengesoknadDTOS ->
+            sykepengesoknadDTOS.size `should be equal to` 3
+            sykepengesoknadDTOS.all { it.status == NY } shouldBe true
+        }
 
-        val soknader = sykepengesoknadKafkaConsumer.ventPåRecords(antall = 3).tilSoknader()
-
-        assertThat(soknader).hasSize(3)
-        assertThat(soknader[0].status).isEqualTo(NY)
-        assertThat(soknader[1].status).isEqualTo(NY)
-        assertThat(soknader[2].status).isEqualTo(NY)
-
-        val hentetViaRest = hentSoknaderMetadata(fnr)
-        assertThat(hentetViaRest).hasSize(3)
+        hentSoknaderMetadata(fnr).size `should be equal to` 3
     }
 
     @Test
@@ -92,154 +78,124 @@ class AutomatiskPapirsykmeldingOpprydningTest : FellesTestOppsett() {
                 fnr = fnr,
             )
 
-        val sendtSoknad =
-            SoknadBesvarer(rSSykepengesoknad = førsteSøknad, testOppsettInterfaces = this, fnr = fnr)
-                .besvarSporsmal(tag = "ANSVARSERKLARING", svar = "CHECKED")
-                .besvarSporsmal(tag = "TILBAKE_I_ARBEID", svar = "NEI")
-                .besvarSporsmal(tag = "FERIE_V2", svar = "NEI")
-                .besvarSporsmal(tag = "PERMISJON_V2", svar = "NEI")
-                .besvarSporsmal(tag = "OPPHOLD_UTENFOR_EOS", svar = "NEI")
-                .besvarSporsmal(tag = "ARBEID_UNDERVEIS_100_PROSENT_0", svar = "NEI")
-                .besvarSporsmal(tag = "ANDRE_INNTEKTSKILDER_V2", svar = "NEI")
-                .oppsummering()
-                .sendSoknad()
-        assertThat(sendtSoknad.status).isEqualTo(RSSoknadstatus.SENDT)
-        val soknader = sykepengesoknadKafkaConsumer.ventPåRecords(antall = 1).tilSoknader()
+        SoknadBesvarer(rSSykepengesoknad = førsteSøknad, testOppsettInterfaces = this, fnr = fnr)
+            .standardSvar()
+            .sendSoknad()
+            .let {
+                it.status `should be equal to` RSSoknadstatus.SENDT
+            }
 
-        assertThat(soknader).hasSize(1)
-        assertThat(soknader[0].status).isEqualTo(SENDT)
+        sykepengesoknadKafkaConsumer
+            .ventPåRecords(antall = 1)
+            .tilSoknader()
+            .shouldHaveSize(1)
+            .single()
+            .status
+            .`should be equal to`(SENDT)
     }
 
     @Test
     fun `3 - vi mottar identisk sykmelding igjen, ingenting endres`() {
-        mockFlexSyketilfelleSykeforloep(sykmelding.id)
+        mockFlexSyketilfelleSykeforloep(papirsykmeldingKafkaMessage.sykmelding.id)
 
-        val sykmeldingKafkaMessage =
-            SykmeldingKafkaMessageDTO(
-                sykmelding = sykmelding,
-                event = sykmeldingStatusKafkaMessageDTO.event,
-                kafkaMetadata = sykmeldingStatusKafkaMessageDTO.kafkaMetadata,
-            )
-
-        behandleSykmeldingOgBestillAktivering.prosesserSykmelding(sykmeldingId, sykmeldingKafkaMessage, SYKMELDINGSENDT_TOPIC)
-
+        behandleSykmeldingOgBestillAktivering.prosesserSykmelding(sykmeldingId, papirsykmeldingKafkaMessage, SYKMELDINGSENDT_TOPIC)
         sykepengesoknadKafkaConsumer.ventPåRecords(antall = 0)
 
-        val hentetViaRest = hentSoknaderMetadata(fnr)
-        assertThat(hentetViaRest).hasSize(3)
-        assertThat(hentetViaRest[0].status).isEqualTo(RSSoknadstatus.SENDT)
-        assertThat(hentetViaRest[1].status).isEqualTo(RSSoknadstatus.NY)
-        assertThat(hentetViaRest[2].status).isEqualTo(RSSoknadstatus.NY)
+        hentSoknaderMetadata(fnr).let {
+            it.size `should be equal to` 3
+            it.first().status `should be equal to` RSSoknadstatus.SENDT
+            it.takeLast(2).all { soknad -> soknad.status == RSSoknadstatus.NY } shouldBe true
+        }
     }
 
     @Test
-    fun `4 - vi mottar en korrigert sykmelding med litt lengre periode, sendt blir korreigert og søknadene opprettes på nytt`() {
-        mockFlexSyketilfelleSykeforloep(sykmelding.id)
-
-        val sykmelding =
-            skapArbeidsgiverSykmelding(
-                sykmeldingId = sykmeldingId,
-                fom = LocalDate.of(2020, 1, 1),
-                tom = LocalDate.of(2020, 4, 15),
+    fun `4 - vi mottar en korrigert sykmelding med lengre periode, sendt blir korrigert og søknadene opprettes på nytt`() {
+        val nyKafkaMessage =
+            papirsykmeldingKafkaMessage.endrePeriode(
+                periode =
+                    heltSykmeldt(
+                        fom = LocalDate.of(2020, 1, 1),
+                        tom = LocalDate.of(2020, 4, 5),
+                    ),
             )
 
-        val sykmeldingKafkaMessage =
-            SykmeldingKafkaMessageDTO(
-                sykmelding = sykmelding,
-                event = sykmeldingStatusKafkaMessageDTO.event,
-                kafkaMetadata = sykmeldingStatusKafkaMessageDTO.kafkaMetadata,
-            )
+        mockFlexSyketilfelleSykeforloep(papirsykmeldingKafkaMessage.sykmelding.id)
 
-        behandleSykmeldingOgBestillAktivering.prosesserSykmelding(sykmeldingId, sykmeldingKafkaMessage, SYKMELDINGSENDT_TOPIC)
+        behandleSykmeldingOgBestillAktivering.prosesserSykmelding(
+            sykmeldingId = sykmeldingId,
+            sykmeldingKafkaMessage = nyKafkaMessage,
+            topic = SYKMELDINGSENDT_TOPIC,
+        )
+        sykepengesoknadKafkaConsumer.ventPåRecords(antall = 6).tilSoknader().let {
+            it.take(2).all { soknad -> soknad.status == SLETTET } shouldBe true
+            it.takeLast(4).all { soknad -> soknad.status == NY } shouldBe true
+        }
 
-        val soknader = sykepengesoknadKafkaConsumer.ventPåRecords(antall = 6).tilSoknader()
-
-        assertThat(soknader[0].status).isEqualTo(SLETTET)
-        assertThat(soknader[1].status).isEqualTo(SLETTET)
-        assertThat(soknader[2].status).isEqualTo(NY)
-        assertThat(soknader[3].status).isEqualTo(NY)
-        assertThat(soknader[4].status).isEqualTo(NY)
-        assertThat(soknader[5].status).isEqualTo(NY)
-
-        val hentetViaRest = hentSoknaderMetadata(fnr)
-        assertThat(hentetViaRest).hasSize(5)
-        assertThat(hentetViaRest[0].status).isEqualTo(RSSoknadstatus.KORRIGERT)
-        assertThat(hentetViaRest[1].status).isEqualTo(RSSoknadstatus.NY)
-        assertThat(hentetViaRest[2].status).isEqualTo(RSSoknadstatus.NY)
-        assertThat(hentetViaRest[3].status).isEqualTo(RSSoknadstatus.NY)
-        assertThat(hentetViaRest[4].status).isEqualTo(RSSoknadstatus.NY)
+        hentSoknaderMetadata(fnr).let {
+            it.first().status `should be equal to` RSSoknadstatus.KORRIGERT
+            it.takeLast(4).all { soknad -> soknad.status == RSSoknadstatus.NY } shouldBe true
+        }
     }
 
     @Test
     fun `5 - vi mottar den korrigerte sykmeldingen igjen, ingenting endres`() {
-        mockFlexSyketilfelleSykeforloep(sykmelding.id)
+        mockFlexSyketilfelleSykeforloep(papirsykmeldingKafkaMessage.sykmelding.id)
 
-        val sykmelding =
-            skapArbeidsgiverSykmelding(
-                sykmeldingId = sykmeldingId,
-                fom = LocalDate.of(2020, 1, 1),
-                tom = LocalDate.of(2020, 4, 15),
+        val nyKafkaMessage =
+            papirsykmeldingKafkaMessage.endrePeriode(
+                periode =
+                    heltSykmeldt(
+                        fom = LocalDate.of(2020, 1, 1),
+                        tom = LocalDate.of(2020, 4, 5),
+                    ),
             )
 
-        val sykmeldingKafkaMessage =
-            SykmeldingKafkaMessageDTO(
-                sykmelding = sykmelding,
-                event = sykmeldingStatusKafkaMessageDTO.event,
-                kafkaMetadata = sykmeldingStatusKafkaMessageDTO.kafkaMetadata,
-            )
-
-        behandleSykmeldingOgBestillAktivering.prosesserSykmelding(sykmeldingId, sykmeldingKafkaMessage, SYKMELDINGSENDT_TOPIC)
+        behandleSykmeldingOgBestillAktivering.prosesserSykmelding(
+            sykmeldingId = sykmeldingId,
+            sykmeldingKafkaMessage = nyKafkaMessage,
+            topic = SYKMELDINGSENDT_TOPIC,
+        )
 
         sykepengesoknadKafkaConsumer.ventPåRecords(antall = 0)
 
-        val hentetViaRest = hentSoknaderMetadata(fnr)
-        assertThat(hentetViaRest).hasSize(5)
-        assertThat(hentetViaRest[0].status).isEqualTo(RSSoknadstatus.KORRIGERT)
-        assertThat(hentetViaRest[1].status).isEqualTo(RSSoknadstatus.NY)
-        assertThat(hentetViaRest[2].status).isEqualTo(RSSoknadstatus.NY)
-        assertThat(hentetViaRest[3].status).isEqualTo(RSSoknadstatus.NY)
-        assertThat(hentetViaRest[4].status).isEqualTo(RSSoknadstatus.NY)
+        hentSoknaderMetadata(fnr).let {
+            it.size `should be equal to` 5
+            it.first().status `should be equal to` RSSoknadstatus.KORRIGERT
+            it.takeLast(4).all { soknad -> soknad.status == RSSoknadstatus.NY } shouldBe true
+        }
     }
 
     @Test
     fun `6 - sykmeldingen korrigeres igjen, men må med annen sykmeldingsgrad`() {
-        mockFlexSyketilfelleSykeforloep(sykmelding.id)
-
-        val sykmelding =
-            skapArbeidsgiverSykmelding(
-                sykmeldingId = sykmeldingId,
-                fom = LocalDate.of(2020, 1, 1),
-                tom = LocalDate.of(2020, 4, 15),
-                type = PeriodetypeDTO.GRADERT,
-                gradert = GradertDTO(grad = 33, reisetilskudd = false),
+        mockFlexSyketilfelleSykeforloep(papirsykmeldingKafkaMessage.sykmelding.id)
+        val nyKafkaMessage =
+            papirsykmeldingKafkaMessage.endrePeriode(
+                periode =
+                    gradertSykmeldt(
+                        fom = LocalDate.of(2020, 1, 1),
+                        tom = LocalDate.of(2020, 4, 5),
+                    ),
             )
 
-        val sykmeldingKafkaMessage =
-            SykmeldingKafkaMessageDTO(
-                sykmelding = sykmelding,
-                event = sykmeldingStatusKafkaMessageDTO.event,
-                kafkaMetadata = sykmeldingStatusKafkaMessageDTO.kafkaMetadata,
-            )
+        behandleSykmeldingOgBestillAktivering.prosesserSykmelding(
+            sykmeldingId = sykmeldingId,
+            sykmeldingKafkaMessage = nyKafkaMessage,
+            topic = SYKMELDINGSENDT_TOPIC,
+        )
 
-        behandleSykmeldingOgBestillAktivering.prosesserSykmelding(sykmeldingId, sykmeldingKafkaMessage, SYKMELDINGSENDT_TOPIC)
+        sykepengesoknadKafkaConsumer.ventPåRecords(antall = 8).tilSoknader().let {
+            it.size `should be equal to` 8
+            it.take(4).all { soknad -> soknad.status == SLETTET } shouldBe true
+            it.takeLast(4).all { soknad -> soknad.status == NY } shouldBe true
+        }
 
-        val soknader = sykepengesoknadKafkaConsumer.ventPåRecords(antall = 8).tilSoknader()
-
-        assertThat(soknader[0].status).isEqualTo(SLETTET)
-        assertThat(soknader[1].status).isEqualTo(SLETTET)
-        assertThat(soknader[2].status).isEqualTo(SLETTET)
-        assertThat(soknader[3].status).isEqualTo(SLETTET)
-        assertThat(soknader[4].status).isEqualTo(NY)
-        assertThat(soknader[5].status).isEqualTo(NY)
-        assertThat(soknader[6].status).isEqualTo(NY)
-        assertThat(soknader[7].status).isEqualTo(NY)
-
-        val hentetViaRest = hentSoknaderMetadata(fnr)
-        assertThat(hentetViaRest).hasSize(5)
-        assertThat(hentetViaRest[0].status).isEqualTo(RSSoknadstatus.KORRIGERT)
-        assertThat(hentetViaRest[1].status).isEqualTo(RSSoknadstatus.NY)
-        assertThat(hentetViaRest[2].status).isEqualTo(RSSoknadstatus.NY)
-        assertThat(hentetViaRest[3].status).isEqualTo(RSSoknadstatus.NY)
-        assertThat(hentetViaRest[4].status).isEqualTo(RSSoknadstatus.NY)
+        hentSoknaderMetadata(fnr).let {
+            it.size `should be equal to` 5
+            it.first().status `should be equal to` RSSoknadstatus.KORRIGERT
+            it.takeLast(4).all { soknad -> soknad.status == RSSoknadstatus.NY } shouldBe true
+        }
     }
+
+    private fun SykmeldingKafkaMessageDTO.endrePeriode(periode: List<SykmeldingsperiodeAGDTO>) =
+        this.copy(sykmelding = this.sykmelding.copy(sykmeldingsperioder = periode))
 }

--- a/src/test/kotlin/no/nav/helse/flex/soknadsopprettelse/GenerellKafkaIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/soknadsopprettelse/GenerellKafkaIntegrationTest.kt
@@ -5,10 +5,15 @@ import com.nhaarman.mockitokotlin2.argWhere
 import com.nhaarman.mockitokotlin2.doThrow
 import com.nhaarman.mockitokotlin2.whenever
 import no.nav.helse.flex.FellesTestOppsett
+import no.nav.helse.flex.controller.domain.sykepengesoknad.RSArbeidssituasjon
 import no.nav.helse.flex.controller.domain.sykepengesoknad.RSSoknadstype
+import no.nav.helse.flex.domain.Arbeidssituasjon
 import no.nav.helse.flex.domain.exception.SkalRebehandlesException
+import no.nav.helse.flex.hentSoknader
 import no.nav.helse.flex.hentSoknaderMetadata
 import no.nav.helse.flex.kafka.consumer.SYKMELDINGSENDT_TOPIC
+import no.nav.helse.flex.mockFlexSyketilfelleArbeidsgiverperiode
+import no.nav.helse.flex.mockFlexSyketilfelleSykeforloep
 import no.nav.helse.flex.mockStandardSyketilfelle
 import no.nav.helse.flex.repository.SykepengesoknadDAO
 import no.nav.helse.flex.testdata.*
@@ -91,6 +96,50 @@ class GenerellKafkaIntegrationTest : FellesTestOppsett() {
             hentSoknaderMetadata(fnr).shouldHaveSize(2)
             sykepengesoknadKafkaConsumer.ventPåRecords(antall = 2)
         }
+    }
+
+    @Test
+    fun `Oppretter søknad og overskriver annen ikke-arbeidstakersøknad med samme sykmeldingId`() {
+        val perioder = heltSykmeldt(fom = datoIFremtiden, tom = datoIFremtiden.plusDays(4))
+
+        val kafkaMessage =
+            sykmeldingKafkaMessage(
+                arbeidssituasjon = Arbeidssituasjon.ARBEIDSLEDIG,
+                fnr = fnr,
+                sykmeldingsperioder = perioder,
+            )
+
+        mockFlexSyketilfelleSykeforloep(kafkaMessage.sykmelding.id, oppfolgingsdato = datoIFremtiden)
+        behandleSykmeldingOgBestillAktivering.prosesserSykmelding(
+            sykmeldingId = kafkaMessage.sykmelding.id,
+            sykmeldingKafkaMessage = kafkaMessage,
+            topic = SYKMELDINGSENDT_TOPIC,
+        )
+
+        sykepengesoknadKafkaConsumer.ventPåRecords(antall = 1)
+        hentSoknaderMetadata(fnr).shouldHaveSize(1)
+        hentSoknader(fnr).single().arbeidssituasjon `should be equal to` RSArbeidssituasjon.ARBEIDSLEDIG
+
+        val sykmeldingKafkaMessageAnnet =
+            sykmeldingKafkaMessage(
+                arbeidssituasjon = Arbeidssituasjon.ANNET,
+                fnr = fnr,
+                sykmeldingId = kafkaMessage.sykmelding.id,
+                sykmeldingsperioder = perioder,
+            )
+
+        flexSyketilfelleMockRestServiceServer.reset()
+        mockFlexSyketilfelleSykeforloep(kafkaMessage.sykmelding.id, oppfolgingsdato = datoIFremtiden)
+
+        behandleSykmeldingOgBestillAktivering.prosesserSykmelding(
+            sykmeldingId = kafkaMessage.sykmelding.id,
+            sykmeldingKafkaMessage = sykmeldingKafkaMessageAnnet,
+            topic = SYKMELDINGSENDT_TOPIC,
+        )
+
+        sykepengesoknadKafkaConsumer.ventPåRecords(antall = 2)
+        hentSoknaderMetadata(fnr).shouldHaveSize(1)
+        hentSoknader(fnr).single().arbeidssituasjon `should be equal to` RSArbeidssituasjon.ANNET
     }
 
     @Nested
@@ -185,6 +234,51 @@ class GenerellKafkaIntegrationTest : FellesTestOppsett() {
             )
 
             hentSoknaderMetadata(fnr).`should be empty`()
+        }
+
+        @Test
+        fun `Oppretter ikke søknad dersom sykmeldingen er brukt på en arbeidstakersøknad`() {
+            val perioder = heltSykmeldt(fom = datoIFremtiden, tom = datoIFremtiden.plusDays(4))
+
+            val kafkaMessage =
+                sykmeldingKafkaMessage(
+                    arbeidssituasjon = Arbeidssituasjon.ARBEIDSTAKER,
+                    fnr = fnr,
+                    sykmeldingsperioder = perioder,
+                )
+
+            mockFlexSyketilfelleArbeidsgiverperiode()
+            mockFlexSyketilfelleSykeforloep(kafkaMessage.sykmelding.id, datoIFremtiden)
+            behandleSykmeldingOgBestillAktivering.prosesserSykmelding(
+                sykmeldingId = kafkaMessage.sykmelding.id,
+                sykmeldingKafkaMessage = kafkaMessage,
+                topic = SYKMELDINGSENDT_TOPIC,
+            )
+
+            sykepengesoknadKafkaConsumer.ventPåRecords(antall = 1)
+            hentSoknaderMetadata(fnr).shouldHaveSize(1)
+            hentSoknader(fnr).single().arbeidssituasjon `should be equal to` RSArbeidssituasjon.ARBEIDSTAKER
+
+            val sykmeldingKafkaMessageNaringsdrivende =
+                sykmeldingKafkaMessage(
+                    arbeidssituasjon = Arbeidssituasjon.NAERINGSDRIVENDE,
+                    fnr = fnr,
+                    sykmeldingId = kafkaMessage.sykmelding.id,
+                    sykmeldingsperioder = perioder,
+                )
+
+            flexSyketilfelleMockRestServiceServer.reset()
+            mockStandardSyketilfelle(kafkaMessage.sykmelding.id, erUtenforVentetid = true, oppfolgingsdato = datoIFremtiden)
+
+            behandleSykmeldingOgBestillAktivering.prosesserSykmelding(
+                sykmeldingId = kafkaMessage.sykmelding.id,
+                sykmeldingKafkaMessage = sykmeldingKafkaMessageNaringsdrivende,
+                topic = SYKMELDINGSENDT_TOPIC,
+            )
+
+            sykepengesoknadKafkaConsumer.ventPåRecords(antall = 0)
+            hentSoknaderMetadata(fnr).shouldHaveSize(1)
+            hentSoknader(fnr).single().arbeidssituasjon `should be equal to` RSArbeidssituasjon.ARBEIDSTAKER
         }
     }
 

--- a/src/test/kotlin/no/nav/helse/flex/soknadsopprettelse/RebehandlingKafkaIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/soknadsopprettelse/RebehandlingKafkaIntegrationTest.kt
@@ -115,7 +115,6 @@ class RebehandlingKafkaIntegrationTest : FellesTestOppsett() {
             ),
     ) = skapArbeidsgiverSykmelding(
         sykmeldingId = sykmeldingStatusKafkaMessageDTO.event.sykmeldingId,
-    ).copy(
         sykmeldingsperioder = sykmeldingsperioder,
         syketilfelleStartDato = syketilfelleStartDato,
     )

--- a/src/test/kotlin/no/nav/helse/flex/soknadsopprettelse/RebehandlingSoknadopprettelseTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/soknadsopprettelse/RebehandlingSoknadopprettelseTest.kt
@@ -128,7 +128,6 @@ class RebehandlingSoknadopprettelseTest : FellesTestOppsett() {
         val sykmelding =
             skapArbeidsgiverSykmelding(
                 sykmeldingId = sykmeldingStatusKafkaMessageDTO.event.sykmeldingId,
-            ).copy(
                 sykmeldingsperioder =
                     listOf(
                         SykmeldingsperiodeAGDTO(

--- a/src/test/kotlin/no/nav/helse/flex/soknadsopprettelse/TilbakedatertSykmeldingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/soknadsopprettelse/TilbakedatertSykmeldingIntegrationTest.kt
@@ -3,11 +3,9 @@ package no.nav.helse.flex.soknadsopprettelse
 import no.nav.helse.flex.*
 import no.nav.helse.flex.domain.Arbeidssituasjon
 import no.nav.helse.flex.kafka.consumer.SYKMELDINGSENDT_TOPIC
-import no.nav.helse.flex.testdata.skapArbeidsgiverSykmelding
-import no.nav.helse.flex.testdata.skapSykmeldingStatusKafkaMessageDTO
+import no.nav.helse.flex.testdata.sykmeldingKafkaMessage
 import no.nav.helse.flex.testutil.SoknadBesvarer
 import no.nav.syfo.model.Merknad
-import no.nav.syfo.sykmelding.kafka.model.SykmeldingKafkaMessageDTO
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldHaveSize
@@ -119,38 +117,19 @@ class TilbakedatertSykmeldingIntegrationTest : FellesTestOppsett() {
     fun sendSykmeldingMedMerknad(merknad: String?) {
         flexSyketilfelleMockRestServiceServer.reset()
 
-        val sykmeldingStatusKafkaMessageDTO =
-            skapSykmeldingStatusKafkaMessageDTO(
+        val kafkaMessage =
+            sykmeldingKafkaMessage(
                 fnr = fnr,
                 arbeidssituasjon = Arbeidssituasjon.ARBEIDSLEDIG,
                 sykmeldingId = sykmeldingid,
+                merknader = if (merknad == null) null else listOf(Merknad(type = merknad, beskrivelse = merknad)),
             )
-        val sykmelding =
-            skapArbeidsgiverSykmelding(
-                sykmeldingId = sykmeldingStatusKafkaMessageDTO.event.sykmeldingId,
-            ).let {
-                if (merknad == null) {
-                    it
-                } else {
-                    it.copy(
-                        merknader = listOf(Merknad(type = merknad, beskrivelse = merknad)),
-                    )
-                }
-            }
-
-        mockFlexSyketilfelleSykeforloep(sykmelding.id)
-
-        val sykmeldingKafkaMessage =
-            SykmeldingKafkaMessageDTO(
-                sykmelding = sykmelding,
-                event = sykmeldingStatusKafkaMessageDTO.event,
-                kafkaMetadata = sykmeldingStatusKafkaMessageDTO.kafkaMetadata,
-            )
+        mockFlexSyketilfelleSykeforloep(kafkaMessage.sykmelding.id)
 
         behandleSykmeldingOgBestillAktivering.prosesserSykmelding(
-            sykmelding.id,
-            sykmeldingKafkaMessage,
-            SYKMELDINGSENDT_TOPIC,
+            sykmeldingId = kafkaMessage.sykmelding.id,
+            sykmeldingKafkaMessage = kafkaMessage,
+            topic = SYKMELDINGSENDT_TOPIC,
         )
     }
 }

--- a/src/test/kotlin/no/nav/helse/flex/soknadsopprettelse/naringsdrivende/NaringsdrivendeFraKafkaIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/soknadsopprettelse/naringsdrivende/NaringsdrivendeFraKafkaIntegrationTest.kt
@@ -375,7 +375,8 @@ class NaringsdrivendeFraKafkaIntegrationTest : FellesTestOppsett() {
         fun `Oppretter 2 søknader for næringsdrivende hvor gradering endres midt i for sykmeldingen lengre enn 31 dager`() {
             val testdata = opprettTestdata()
             val sykmelding =
-                skapArbeidsgiverSykmelding(sykmeldingId = testdata.sykmeldingId).copy(
+                skapArbeidsgiverSykmelding(
+                    sykmeldingId = testdata.sykmeldingId,
                     sykmeldingsperioder =
                         listOf(
                             SykmeldingsperiodeAGDTO(

--- a/src/test/kotlin/no/nav/helse/flex/testdata/SykmeldingGenerator.kt
+++ b/src/test/kotlin/no/nav/helse/flex/testdata/SykmeldingGenerator.kt
@@ -79,6 +79,55 @@ fun skapArbeidsgiverSykmelding(
         utenlandskSykmelding = null,
     )
 
+fun skapArbeidsgiverSykmelding(
+    sykmeldingId: String = UUID.randomUUID().toString(),
+    sykmeldingsperioder: List<SykmeldingsperiodeAGDTO>? =
+        lagSykmeldingsPerioder(
+            fom = LocalDate.of(2020, 2, 1),
+            tom = LocalDate.of(2020, 2, 15),
+        ),
+    merknader: List<Merknad>? = null,
+    utenlandskSykemelding: UtenlandskSykmeldingAGDTO? = null,
+    sykmeldingSkrevet: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC),
+    signaturDato: OffsetDateTime = sykmeldingSkrevet,
+    syketilfelleStartDato: LocalDate? = null,
+    erPapirsykmelding: Boolean? = false,
+): ArbeidsgiverSykmeldingDTO =
+    ArbeidsgiverSykmeldingDTO(
+        id = sykmeldingId,
+        sykmeldingsperioder = sykmeldingsperioder ?: emptyList(),
+        behandletTidspunkt = sykmeldingSkrevet,
+        signaturDato = signaturDato,
+        mottattTidspunkt = OffsetDateTime.now(ZoneOffset.UTC),
+        arbeidsgiver = ArbeidsgiverAGDTO(null, null),
+        syketilfelleStartDato = syketilfelleStartDato,
+        egenmeldt = false,
+        harRedusertArbeidsgiverperiode = false,
+        behandler =
+            BehandlerAGDTO(
+                fornavn = "Lege",
+                mellomnavn = null,
+                etternavn = "Legesen",
+                hpr = null,
+                adresse =
+                    AdresseDTO(
+                        gate = null,
+                        postnummer = null,
+                        kommune = null,
+                        postboks = null,
+                        land = null,
+                    ),
+                tlf = null,
+            ),
+        kontaktMedPasient = KontaktMedPasientAGDTO(null),
+        meldingTilArbeidsgiver = null,
+        tiltakArbeidsplassen = null,
+        prognose = null,
+        papirsykmelding = erPapirsykmelding ?: false,
+        merknader = merknader,
+        utenlandskSykmelding = utenlandskSykemelding,
+    )
+
 fun skapArbeidsgiverSykmeldingTilSoknadOpprettelse(
     sykmeldingId: String = UUID.randomUUID().toString(),
     fom: LocalDate = LocalDate.of(2020, 2, 1),
@@ -113,6 +162,7 @@ fun skapArbeidsgiverSykmeldingTilSoknadOpprettelse(
         arbeidsgiverOrgnummer = null,
         arbeidsgiverNavn = null,
         tidligereArbeidsgiverOrgnummer = null,
+        erPapirsykmelding = false,
     )
 
 fun skapSykmeldingStatusKafkaMessageDTO(
@@ -201,54 +251,6 @@ fun lagFiskerInnsendtSkjemaSvar(arbeidssituasjon: Arbeidssituasjon): KomplettInn
 
     return lagKomplettInnsendtSkjemaSvar(arbeidssituasjon, fiskerSvar)
 }
-
-fun skapArbeidsgiverSykmelding(
-    sykmeldingId: String = UUID.randomUUID().toString(),
-    sykmeldingsperioder: List<SykmeldingsperiodeAGDTO>? =
-        lagSykmeldingsPerioder(
-            fom = LocalDate.of(2020, 2, 1),
-            tom = LocalDate.of(2020, 2, 15),
-        ),
-    merknader: List<Merknad>? = null,
-    utenlandskSykemelding: UtenlandskSykmeldingAGDTO? = null,
-    sykmeldingSkrevet: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC),
-    signaturDato: OffsetDateTime = sykmeldingSkrevet,
-    syketilfelleStartDato: LocalDate? = null,
-): ArbeidsgiverSykmeldingDTO =
-    ArbeidsgiverSykmeldingDTO(
-        id = sykmeldingId,
-        sykmeldingsperioder = sykmeldingsperioder ?: emptyList(),
-        behandletTidspunkt = sykmeldingSkrevet,
-        signaturDato = signaturDato,
-        mottattTidspunkt = OffsetDateTime.now(ZoneOffset.UTC),
-        arbeidsgiver = ArbeidsgiverAGDTO(null, null),
-        syketilfelleStartDato = syketilfelleStartDato,
-        egenmeldt = false,
-        harRedusertArbeidsgiverperiode = false,
-        behandler =
-            BehandlerAGDTO(
-                fornavn = "Lege",
-                mellomnavn = null,
-                etternavn = "Legesen",
-                hpr = null,
-                adresse =
-                    AdresseDTO(
-                        gate = null,
-                        postnummer = null,
-                        kommune = null,
-                        postboks = null,
-                        land = null,
-                    ),
-                tlf = null,
-            ),
-        kontaktMedPasient = KontaktMedPasientAGDTO(null),
-        meldingTilArbeidsgiver = null,
-        tiltakArbeidsplassen = null,
-        prognose = null,
-        papirsykmelding = false,
-        merknader = merknader,
-        utenlandskSykmelding = utenlandskSykemelding,
-    )
 
 fun lagSykmeldingsPerioder(
     fom: LocalDate,
@@ -387,6 +389,7 @@ fun sykmeldingKafkaMessage(
     utenlandskSykemelding: UtenlandskSykmeldingAGDTO? = null,
     sykmeldingSkrevet: OffsetDateTime = timestamp,
     signaturDato: OffsetDateTime = timestamp,
+    erPapirsykmelding: Boolean = false,
     tidligereArbeidsgiverOrgnummer: String? = null,
     status: String? = null,
     syketilfelleStartDato: LocalDate? = null,
@@ -425,6 +428,7 @@ fun sykmeldingKafkaMessage(
             sykmeldingSkrevet = sykmeldingSkrevet,
             signaturDato = signaturDato,
             syketilfelleStartDato = syketilfelleStartDato,
+            erPapirsykmelding = erPapirsykmelding,
         )
 
     return SykmeldingKafkaMessageDTO(


### PR DESCRIPTION
Når en sykmelding mottas og det allerede finnes en aktiv arbeidstakersøknad for samme sykmelding, opprettes det ikke lenger nye søknader. Dette hindrer sletting av arbeidstakersøknad dersom det er lag på kafka topic syfo-bekreftet-sykmelding, og bruker endrer fra feks næringsdrivende til arbeidstaker.

Unntak: Papir- og utenlandske sykmeldinger kan fremdeles gi nye søknader selv om en arbeidstakersøknad allerede finnes. Disse korrigeres manuelt av veileder, og det er forventet at søknaden skal oppdateres når sykmeldingen rettes.