### PR TITLE
Beregn ventetid kun for sykmeldinger som er sendt eller bekreftet

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/client/flexsyketilfelle/FlexSyketilfelleClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/client/flexsyketilfelle/FlexSyketilfelleClient.kt
@@ -202,6 +202,7 @@ class FlexSyketilfelleEksternClient(
         val body =
             VentetidRequest(
                 sykmeldingKafkaMessage = sykmeldingKafkaMessage,
+                kunSendtBekreftet = true,
             )
 
         val response =
@@ -229,6 +230,7 @@ class FlexSyketilfelleEksternClient(
 data class VentetidRequest(
     val tilleggsopplysninger: Tilleggsopplysninger? = null,
     val sykmeldingKafkaMessage: SykmeldingKafkaMessageDTO? = null,
+    val kunSendtBekreftet: Boolean = false,
 )
 
 data class SammeVentetidResponse(

--- a/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/SkalOppretteSoknader.kt
+++ b/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/SkalOppretteSoknader.kt
@@ -27,7 +27,11 @@ class SkalOppretteSoknader(
             flexSyketilfelleClient.erUtenforVentetid(
                 identer = identer,
                 sykmeldingId = sykmeldingId,
-                ventetidRequest = VentetidRequest(sykmeldingKafkaMessage = sykmeldingKafkaMessage),
+                ventetidRequest =
+                    VentetidRequest(
+                        sykmeldingKafkaMessage = sykmeldingKafkaMessage,
+                        kunSendtBekreftet = true,
+                    ),
             )
 
         if (!erUtenforVentetid && !brukerHarOppgittForsikring) {


### PR DESCRIPTION
Lagt til parameter 'kunSendtBekrefte', som kan gjøres obligatorisk i
flex-syketilfelle så fort vi vet vi ikke gjør kallet fra
flex-sykmeldinger-backed,
