### PR TITLE
Fjern default felt kunSendtBekreftet

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/client/flexsyketilfelle/FlexSyketilfelleClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/client/flexsyketilfelle/FlexSyketilfelleClient.kt
@@ -198,11 +198,7 @@ class FlexSyketilfelleEksternClient(
                     "perioderMedSammeVentetid",
                 ).queryParam("hentAndreIdenter", "false")
 
-        val body =
-            VentetidRequest(
-                sykmeldingKafkaMessage = sykmeldingKafkaMessage,
-                kunSendtBekreftet = true,
-            )
+        val body = VentetidRequest(sykmeldingKafkaMessage = sykmeldingKafkaMessage)
 
         val response =
             flexSyketilfelleRestTemplate
@@ -228,7 +224,6 @@ class FlexSyketilfelleEksternClient(
 
 data class VentetidRequest(
     val sykmeldingKafkaMessage: SykmeldingKafkaMessageDTO? = null,
-    val kunSendtBekreftet: Boolean = false,
 )
 
 data class SammeVentetidResponse(

--- a/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/SkalOppretteSoknader.kt
+++ b/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/SkalOppretteSoknader.kt
@@ -27,11 +27,7 @@ class SkalOppretteSoknader(
             flexSyketilfelleClient.erUtenforVentetid(
                 identer = identer,
                 sykmeldingId = sykmeldingId,
-                ventetidRequest =
-                    VentetidRequest(
-                        sykmeldingKafkaMessage = sykmeldingKafkaMessage,
-                        kunSendtBekreftet = true,
-                    ),
+                ventetidRequest = VentetidRequest(sykmeldingKafkaMessage = sykmeldingKafkaMessage),
             )
 
         if (!erUtenforVentetid && !brukerHarOppgittForsikring) {


### PR DESCRIPTION
Trengs ikke ved kall til flex-syketilfelle, som nå
håndterer samme funksjonalitet som default.
