### PR TITLE
Sjekk om søknad eksisterer for sykmelding

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/controller/SoknadBrukerController.kt
+++ b/src/main/kotlin/no/nav/helse/flex/controller/SoknadBrukerController.kt
@@ -3,6 +3,7 @@ package no.nav.helse.flex.controller
 import io.swagger.v3.oas.annotations.tags.Tag
 import no.nav.helse.flex.config.EnvironmentToggles
 import no.nav.helse.flex.config.OIDCIssuer.TOKENX
+import no.nav.helse.flex.controller.domain.RSHarSoknadForSykmeldingResponse
 import no.nav.helse.flex.controller.domain.RSMottakerResponse
 import no.nav.helse.flex.controller.domain.RSOppdaterSporsmalResponse
 import no.nav.helse.flex.controller.domain.sykepengesoknad.RSMottaker
@@ -28,6 +29,7 @@ import no.nav.helse.flex.frisktilarbeid.FjernFremtidigeFtaSoknaderService
 import no.nav.helse.flex.inntektsopplysninger.InntektsopplysningForNaringsdrivende
 import no.nav.helse.flex.logger
 import no.nav.helse.flex.oppdatersporsmal.soknad.OppdaterSporsmalService
+import no.nav.helse.flex.repository.SykepengesoknadRepository
 import no.nav.helse.flex.sending.SoknadSender
 import no.nav.helse.flex.service.AvbrytSoknadService
 import no.nav.helse.flex.service.EttersendingSoknadService
@@ -70,6 +72,7 @@ class SoknadBrukerController(
     private val inntektsopplysningForNaringsdrivende: InntektsopplysningForNaringsdrivende,
     private val oppholdUtenforEOSService: OppholdUtenforEOSService,
     private val fjernFremtidigeFtaSoknaderService: FjernFremtidigeFtaSoknaderService,
+    private val sykepengesoknadRepository: SykepengesoknadRepository,
     @param:Value("\${DITT_SYKEFRAVAER_FRONTEND_CLIENT_ID}")
     val dittSykefravaerFrontendClientId: String,
     @param:Value("\${SYKEPENGESOKNAD_FRONTEND_CLIENT_ID}")
@@ -84,6 +87,23 @@ class SoknadBrukerController(
         val identer =
             contextHolder.validerTokenXClaims(dittSykefravaerFrontendClientId, sykepengesoknadFrontendClientId).hentIdenter()
         return hentSoknadService.hentSoknaderUtenSporsmal(identer).map { it.tilRSSykepengesoknadMetadata() }
+    }
+
+    @ProtectedWithClaims(issuer = TOKENX, combineWithOr = true, claimMap = ["acr=Level4", "acr=idporten-loa-high"])
+    @ResponseBody
+    @GetMapping(value = ["/soknader/sykmelding/{sykmeldingUuid}/harSoknad"], produces = [APPLICATION_JSON_VALUE])
+    fun harSoknadForSykmelding(
+        @PathVariable sykmeldingUuid: String,
+    ): RSHarSoknadForSykmeldingResponse {
+        val identer = contextHolder.validerTokenXClaims(dittSykefravaerFrontendClientId).hentIdenter()
+        val soknader = sykepengesoknadRepository.findBySykmeldingUuid(sykmeldingUuid)
+
+        val soknadFinnes = soknader.isNotEmpty()
+        if (soknadFinnes && soknader.any { it.fnr !in identer.alle() }) {
+            throw IkkeTilgangException("Er ikke eier")
+        }
+
+        return RSHarSoknadForSykmeldingResponse(harSoknad = soknadFinnes)
     }
 
     @ProtectedWithClaims(issuer = TOKENX, combineWithOr = true, claimMap = ["acr=Level4", "acr=idporten-loa-high"])

--- a/src/main/kotlin/no/nav/helse/flex/controller/domain/RSHarSoknadForSykmeldingResponse.kt
+++ b/src/main/kotlin/no/nav/helse/flex/controller/domain/RSHarSoknadForSykmeldingResponse.kt
@@ -1,0 +1,5 @@
+package no.nav.helse.flex.controller.domain
+
+data class RSHarSoknadForSykmeldingResponse(
+    val harSoknad: Boolean,
+)

--- a/src/test/kotlin/no/nav/helse/flex/controller/SykmeldingHarSoknadTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/controller/SykmeldingHarSoknadTest.kt
@@ -1,0 +1,116 @@
+package no.nav.helse.flex.controller
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.helse.flex.FakesTestOppsett
+import no.nav.helse.flex.controller.domain.RSHarSoknadForSykmeldingResponse
+import no.nav.helse.flex.domain.Arbeidssituasjon
+import no.nav.helse.flex.domain.Soknadstatus
+import no.nav.helse.flex.domain.Soknadstype
+import no.nav.helse.flex.fakes.SoknadLagrerFake
+import no.nav.helse.flex.testutil.lagSoknad
+import no.nav.helse.flex.tokenxToken
+import no.nav.helse.flex.util.objectMapper
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDate
+import java.util.UUID
+
+class SykmeldingHarSoknadTest : FakesTestOppsett() {
+    @Autowired
+    private lateinit var soknadLagrer: SoknadLagrerFake
+
+    private val fnr = "12345678901"
+
+    @Test
+    fun `returnerer harSoknad=true når søknad finnes for sykmelding`() {
+        val sykmeldingUuid = UUID.randomUUID().toString()
+
+        soknadLagrer.lagreSoknad(
+            lagSoknad(
+                fnr = fnr,
+                arbeidsgiver = 1,
+                fom = LocalDate.now().minusDays(14),
+                tom = LocalDate.now(),
+                startSykeforlop = LocalDate.now().minusDays(14),
+                arbeidsSituasjon = Arbeidssituasjon.ARBEIDSTAKER,
+                soknadsType = Soknadstype.ARBEIDSTAKERE,
+                status = Soknadstatus.NY,
+                sykmeldingId = sykmeldingUuid,
+            ),
+        )
+
+        val response = hentHarSoknadForSykmelding(sykmeldingUuid, fnr)
+        response.harSoknad `should be equal to` true
+    }
+
+    @Test
+    fun `returnerer harSoknad=false når ingen søknad finnes for sykmelding`() {
+        val response = hentHarSoknadForSykmelding(UUID.randomUUID().toString(), fnr)
+        response.harSoknad `should be equal to` false
+    }
+
+    @Test
+    fun `returnerer 403 når søknad tilhører annen bruker`() {
+        val sykmeldingUuid = UUID.randomUUID().toString()
+        val annetFnr = "99999999999"
+
+        soknadLagrer.lagreSoknad(
+            lagSoknad(
+                fnr = annetFnr,
+                arbeidsgiver = 1,
+                fom = LocalDate.now().minusDays(14),
+                tom = LocalDate.now(),
+                startSykeforlop = LocalDate.now().minusDays(14),
+                arbeidsSituasjon = Arbeidssituasjon.ARBEIDSTAKER,
+                soknadsType = Soknadstype.ARBEIDSTAKERE,
+                status = Soknadstatus.NY,
+                sykmeldingId = sykmeldingUuid,
+            ),
+        )
+
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .get("/api/v2/soknader/sykmelding/$sykmeldingUuid/harSoknad")
+                    .header(
+                        "Authorization",
+                        "Bearer ${server.tokenxToken(fnr = fnr, clientId = "ditt-sykefravaer-frontend-client-id")}",
+                    ).contentType(MediaType.APPLICATION_JSON),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `returnerer 401 uten token`() {
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .get("/api/v2/soknader/sykmelding/${UUID.randomUUID()}/harSoknad")
+                    .contentType(MediaType.APPLICATION_JSON),
+            ).andExpect(status().isUnauthorized)
+    }
+
+    private fun hentHarSoknadForSykmelding(
+        sykmeldingUuid: String,
+        fnr: String,
+        clientId: String = "ditt-sykefravaer-frontend-client-id",
+    ): RSHarSoknadForSykmeldingResponse {
+        val json =
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .get("/api/v2/soknader/sykmelding/$sykmeldingUuid/harSoknad")
+                        .header(
+                            "Authorization",
+                            "Bearer ${server.tokenxToken(fnr = fnr, clientId = clientId)}",
+                        ).contentType(MediaType.APPLICATION_JSON),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+
+        return objectMapper.readValue(json)
+    }
+}


### PR DESCRIPTION
## Beskrivelse
Legger til nytt REST-endepunkt som sjekker om det eksisterer søknad for en gitt sykmelding.

Endepunktet kalles fra ditt-sykefravaer (frontend) og bruker TokenX for autentisering og tilgangsstyring.

**Bygger på PR #1473** (fake repository-støtte).

## Endringer
- Nytt endepunkt: `GET /api/v2/soknader/sykmelding/{sykmeldingUuid}/harSoknad`
- TokenX-beskyttet med tilgangskontroll (kun ditt-sykefravaer)
- Returnerer `{ harSoknad: boolean }`
- Kaster 403 dersom søknaden tilhører annen bruker

## Test (FakesTestOppsett)
- `harSoknad=true` når søknad finnes
- `harSoknad=false` når ingen søknad finnes
- 403 Forbidden når søknad tilhører annen bruker
- 401 Unauthorized uten token