### PR TITLE
Legg til harSoknad-endepunkt for sykmelding

### DIFF
--- a/nais/app/dev.yaml
+++ b/nais/app/dev.yaml
@@ -56,3 +56,4 @@ env:
   ARBEIDSSOEKERREGISTERET_API_URL: http://paw-arbeidssoekerregisteret-api-oppslag-v2.paw
   FLEX_SYKMELDINGER_BACKEND_API_TARGET: api://dev-gcp.flex.flex-sykmeldinger-backend/.default
   FLEX_SYKMELDINGER_BACKEND_API_URL: http://flex-sykmeldinger-backend
+  FLEX_SYKMELDINGER_BACKEND_TOKENX_CLIENT_ID: dev-gcp:flex:flex-sykmeldinger-backend

--- a/nais/app/naiserator.yaml
+++ b/nais/app/naiserator.yaml
@@ -106,6 +106,7 @@ spec:
       rules:
         - application: ditt-sykefravaer
         - application: sykepengesoknad
+        - application: flex-sykmeldinger-backend
         - application: sykepengesoknad-arkivering-oppgave
         - application: flex-internal-frontend
         - application: syfomodiaperson

--- a/nais/app/prod.yaml
+++ b/nais/app/prod.yaml
@@ -59,3 +59,4 @@ env:
   ARBEIDSSOEKERREGISTERET_API_URL: http://paw-arbeidssoekerregisteret-api-oppslag-v2.paw
   FLEX_SYKMELDINGER_BACKEND_API_TARGET: api://prod-gcp.flex.flex-sykmeldinger-backend/.default
   FLEX_SYKMELDINGER_BACKEND_API_URL: http://flex-sykmeldinger-backend
+  FLEX_SYKMELDINGER_BACKEND_TOKENX_CLIENT_ID: prod-gcp:flex:flex-sykmeldinger-backend

--- a/src/main/kotlin/no/nav/helse/flex/controller/SoknadBrukerController.kt
+++ b/src/main/kotlin/no/nav/helse/flex/controller/SoknadBrukerController.kt
@@ -3,6 +3,7 @@ package no.nav.helse.flex.controller
 import io.swagger.v3.oas.annotations.tags.Tag
 import no.nav.helse.flex.config.EnvironmentToggles
 import no.nav.helse.flex.config.OIDCIssuer.TOKENX
+import no.nav.helse.flex.controller.domain.RSHarSoknadForSykmeldingResponse
 import no.nav.helse.flex.controller.domain.RSMottakerResponse
 import no.nav.helse.flex.controller.domain.RSOppdaterSporsmalResponse
 import no.nav.helse.flex.controller.domain.sykepengesoknad.RSMottaker
@@ -28,6 +29,7 @@ import no.nav.helse.flex.frisktilarbeid.FjernFremtidigeFtaSoknaderService
 import no.nav.helse.flex.inntektsopplysninger.InntektsopplysningForNaringsdrivende
 import no.nav.helse.flex.logger
 import no.nav.helse.flex.oppdatersporsmal.soknad.OppdaterSporsmalService
+import no.nav.helse.flex.repository.SykepengesoknadRepository
 import no.nav.helse.flex.sending.SoknadSender
 import no.nav.helse.flex.service.AvbrytSoknadService
 import no.nav.helse.flex.service.EttersendingSoknadService
@@ -70,6 +72,7 @@ class SoknadBrukerController(
     private val inntektsopplysningForNaringsdrivende: InntektsopplysningForNaringsdrivende,
     private val oppholdUtenforEOSService: OppholdUtenforEOSService,
     private val fjernFremtidigeFtaSoknaderService: FjernFremtidigeFtaSoknaderService,
+    private val sykepengesoknadRepository: SykepengesoknadRepository,
     @param:Value("\${DITT_SYKEFRAVAER_FRONTEND_CLIENT_ID}")
     val dittSykefravaerFrontendClientId: String,
     @param:Value("\${SYKEPENGESOKNAD_FRONTEND_CLIENT_ID}")
@@ -84,6 +87,23 @@ class SoknadBrukerController(
         val identer =
             contextHolder.validerTokenXClaims(dittSykefravaerFrontendClientId, sykepengesoknadFrontendClientId).hentIdenter()
         return hentSoknadService.hentSoknaderUtenSporsmal(identer).map { it.tilRSSykepengesoknadMetadata() }
+    }
+
+    @ProtectedWithClaims(issuer = TOKENX, combineWithOr = true, claimMap = ["acr=Level4", "acr=idporten-loa-high"])
+    @ResponseBody
+    @GetMapping(value = ["/soknader/sykmelding/{sykmeldingUuid}/harSoknad"], produces = [APPLICATION_JSON_VALUE])
+    fun harSoknadForSykmelding(
+        @PathVariable sykmeldingUuid: String,
+    ): RSHarSoknadForSykmeldingResponse {
+        val identer = contextHolder.validerTokenXClaims(dittSykefravaerFrontendClientId).hentIdenter()
+        val soknader = sykepengesoknadRepository.findBySykmeldingUuid(sykmeldingUuid)
+
+        val soknadFinnes = soknader.isNotEmpty()
+        if (soknadFinnes && soknader.any { it.fnr !in identer.alle() }) {
+            throw IkkeTilgangException("Er ikke eier")
+        }
+
+        return RSHarSoknadForSykmeldingResponse(harSoknad = soknadFinnes)
     }
 
     @ProtectedWithClaims(issuer = TOKENX, combineWithOr = true, claimMap = ["acr=Level4", "acr=idporten-loa-high"])

--- a/src/main/kotlin/no/nav/helse/flex/controller/SoknadBrukerController.kt
+++ b/src/main/kotlin/no/nav/helse/flex/controller/SoknadBrukerController.kt
@@ -77,6 +77,8 @@ class SoknadBrukerController(
     val dittSykefravaerFrontendClientId: String,
     @param:Value("\${SYKEPENGESOKNAD_FRONTEND_CLIENT_ID}")
     val sykepengesoknadFrontendClientId: String,
+    @param:Value("\${FLEX_SYKMELDINGER_BACKEND_TOKENX_CLIENT_ID}")
+    val flexSykmeldingerBackendTokenxClientId: String,
 ) {
     private val log = logger()
 
@@ -95,7 +97,7 @@ class SoknadBrukerController(
     fun harSoknadForSykmelding(
         @PathVariable sykmeldingUuid: String,
     ): RSHarSoknadForSykmeldingResponse {
-        val identer = contextHolder.validerTokenXClaims(dittSykefravaerFrontendClientId).hentIdenter()
+        val identer = contextHolder.validerTokenXClaims(flexSykmeldingerBackendTokenxClientId).hentIdenter()
         val soknader = sykepengesoknadRepository.findBySykmeldingUuid(sykmeldingUuid)
 
         val soknadFinnes = soknader.isNotEmpty()

--- a/src/main/kotlin/no/nav/helse/flex/controller/domain/RSHarSoknadForSykmeldingResponse.kt
+++ b/src/main/kotlin/no/nav/helse/flex/controller/domain/RSHarSoknadForSykmeldingResponse.kt
@@ -1,0 +1,5 @@
+package no.nav.helse.flex.controller.domain
+
+data class RSHarSoknadForSykmeldingResponse(
+    val harSoknad: Boolean,
+)

--- a/src/test/kotlin/no/nav/helse/flex/controller/SykmeldingHarSoknadTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/controller/SykmeldingHarSoknadTest.kt
@@ -1,0 +1,116 @@
+package no.nav.helse.flex.controller
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.helse.flex.FakesTestOppsett
+import no.nav.helse.flex.controller.domain.RSHarSoknadForSykmeldingResponse
+import no.nav.helse.flex.domain.Arbeidssituasjon
+import no.nav.helse.flex.domain.Soknadstatus
+import no.nav.helse.flex.domain.Soknadstype
+import no.nav.helse.flex.fakes.SoknadLagrerFake
+import no.nav.helse.flex.testutil.lagSoknad
+import no.nav.helse.flex.tokenxToken
+import no.nav.helse.flex.util.objectMapper
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDate
+import java.util.UUID
+
+class SykmeldingHarSoknadTest : FakesTestOppsett() {
+    @Autowired
+    private lateinit var soknadLagrer: SoknadLagrerFake
+
+    private val fnr = "12345678901"
+
+    @Test
+    fun `returnerer harSoknad=true når søknad finnes for sykmelding`() {
+        val sykmeldingUuid = UUID.randomUUID().toString()
+
+        soknadLagrer.lagreSoknad(
+            lagSoknad(
+                fnr = fnr,
+                arbeidsgiver = 1,
+                fom = LocalDate.now().minusDays(14),
+                tom = LocalDate.now(),
+                startSykeforlop = LocalDate.now().minusDays(14),
+                arbeidsSituasjon = Arbeidssituasjon.ARBEIDSTAKER,
+                soknadsType = Soknadstype.ARBEIDSTAKERE,
+                status = Soknadstatus.NY,
+                sykmeldingId = sykmeldingUuid,
+            ),
+        )
+
+        val response = hentHarSoknadForSykmelding(sykmeldingUuid, fnr)
+        response.harSoknad `should be equal to` true
+    }
+
+    @Test
+    fun `returnerer harSoknad=false når ingen søknad finnes for sykmelding`() {
+        val response = hentHarSoknadForSykmelding(UUID.randomUUID().toString(), fnr)
+        response.harSoknad `should be equal to` false
+    }
+
+    @Test
+    fun `returnerer 403 når søknad tilhører annen bruker`() {
+        val sykmeldingUuid = UUID.randomUUID().toString()
+        val annetFnr = "99999999999"
+
+        soknadLagrer.lagreSoknad(
+            lagSoknad(
+                fnr = annetFnr,
+                arbeidsgiver = 1,
+                fom = LocalDate.now().minusDays(14),
+                tom = LocalDate.now(),
+                startSykeforlop = LocalDate.now().minusDays(14),
+                arbeidsSituasjon = Arbeidssituasjon.ARBEIDSTAKER,
+                soknadsType = Soknadstype.ARBEIDSTAKERE,
+                status = Soknadstatus.NY,
+                sykmeldingId = sykmeldingUuid,
+            ),
+        )
+
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .get("/api/v2/soknader/sykmelding/$sykmeldingUuid/harSoknad")
+                    .header(
+                        "Authorization",
+                        "Bearer ${server.tokenxToken(fnr = fnr, clientId = "ditt-sykefravaer-frontend-client-id")}",
+                    ).contentType(MediaType.APPLICATION_JSON),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `returnerer 401 uten token`() {
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders
+                    .get("/api/v2/soknader/sykmelding/${UUID.randomUUID()}/harSoknad")
+                    .contentType(MediaType.APPLICATION_JSON),
+            ).andExpect(status().isUnauthorized)
+    }
+
+    private fun hentHarSoknadForSykmelding(
+        sykmeldingUuid: String,
+        fnr: String,
+        clientId: String = "ditt-sykefravaer-frontend-client-id",
+    ): RSHarSoknadForSykmeldingResponse {
+        val json =
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .get("/api/v2/soknader/sykmelding/$sykmeldingUuid/harSoknad")
+                        .header(
+                            "Authorization",
+                            "Bearer ${server.tokenxToken(fnr = fnr, clientId = clientId)}",
+                        ).contentType(MediaType.APPLICATION_JSON),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+
+        return objectMapper.readValue(json)
+    }
+}

--- a/src/test/kotlin/no/nav/helse/flex/controller/SykmeldingHarSoknadTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/controller/SykmeldingHarSoknadTest.kt
@@ -78,7 +78,7 @@ class SykmeldingHarSoknadTest : FakesTestOppsett() {
                     .get("/api/v2/soknader/sykmelding/$sykmeldingUuid/harSoknad")
                     .header(
                         "Authorization",
-                        "Bearer ${server.tokenxToken(fnr = fnr, clientId = "ditt-sykefravaer-frontend-client-id")}",
+                        "Bearer ${server.tokenxToken(fnr = fnr, clientId = "flex-sykmeldinger-backend-client-id")}",
                     ).contentType(MediaType.APPLICATION_JSON),
             ).andExpect(status().isForbidden)
     }
@@ -96,7 +96,7 @@ class SykmeldingHarSoknadTest : FakesTestOppsett() {
     private fun hentHarSoknadForSykmelding(
         sykmeldingUuid: String,
         fnr: String,
-        clientId: String = "ditt-sykefravaer-frontend-client-id",
+        clientId: String = "flex-sykmeldinger-backend-client-id",
     ): RSHarSoknadForSykmeldingResponse {
         val json =
             mockMvc

--- a/src/test/kotlin/no/nav/helse/flex/fakes/SykepengesoknadRepositoryFake.kt
+++ b/src/test/kotlin/no/nav/helse/flex/fakes/SykepengesoknadRepositoryFake.kt
@@ -41,9 +41,10 @@ class SykepengesoknadRepositoryFake :
 
     override fun findByFnrIn(fnrs: List<String>): List<SykepengesoknadDbRecord> = findAll().filter { it.fnr in fnrs }
 
-    override fun findBySykmeldingUuid(sykmeldingUuid: String): List<SykepengesoknadDbRecord> {
-        TODO("Not yet implemented")
-    }
+    override fun findBySykmeldingUuid(sykmeldingUuid: String): List<SykepengesoknadDbRecord> =
+        findAll().filter {
+            it.sykmeldingUuid == sykmeldingUuid
+        }
 
     override fun findBySykmeldingUuidIn(sykmeldingUuid: Set<String>): List<SykepengesoknadDbRecord> =
         findAll().filter {

--- a/src/test/kotlin/no/nav/helse/flex/fakes/SykepengesoknadRepositoryFakeTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/fakes/SykepengesoknadRepositoryFakeTest.kt
@@ -1,0 +1,57 @@
+package no.nav.helse.flex.fakes
+
+import no.nav.helse.flex.domain.Arbeidssituasjon
+import no.nav.helse.flex.domain.Soknadstatus
+import no.nav.helse.flex.domain.Soknadstype
+import no.nav.helse.flex.repository.normaliser
+import no.nav.helse.flex.testutil.lagSoknad
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.UUID
+
+class SykepengesoknadRepositoryFakeTest {
+    private val repository = SykepengesoknadRepositoryFake()
+
+    @Test
+    fun `finner soknader for sykmeldingUuid`() {
+        val sykmeldingUuid = UUID.randomUUID().toString()
+        val annenSykmeldingUuid = UUID.randomUUID().toString()
+
+        lagreSoknad(sykmeldingUuid = sykmeldingUuid, fnr = "11111111111", arbeidsgiver = 1)
+        lagreSoknad(sykmeldingUuid = sykmeldingUuid, fnr = "22222222222", arbeidsgiver = 2)
+        lagreSoknad(sykmeldingUuid = annenSykmeldingUuid, fnr = "33333333333", arbeidsgiver = 3)
+
+        val funnet = repository.findBySykmeldingUuid(sykmeldingUuid)
+
+        funnet.size `should be equal to` 2
+        funnet.all { it.sykmeldingUuid == sykmeldingUuid } `should be equal to` true
+    }
+
+    @Test
+    fun `returnerer tom liste nar sykmeldingUuid ikke finnes`() {
+        val funnet = repository.findBySykmeldingUuid(UUID.randomUUID().toString())
+
+        funnet.isEmpty() `should be equal to` true
+    }
+
+    private fun lagreSoknad(
+        sykmeldingUuid: String,
+        fnr: String,
+        arbeidsgiver: Int,
+    ) {
+        repository.lagreSoknad(
+            lagSoknad(
+                fnr = fnr,
+                arbeidsgiver = arbeidsgiver,
+                fom = LocalDate.of(2024, 1, 1),
+                tom = LocalDate.of(2024, 1, 31),
+                startSykeforlop = LocalDate.of(2024, 1, 1),
+                arbeidsSituasjon = Arbeidssituasjon.ARBEIDSTAKER,
+                soknadsType = Soknadstype.ARBEIDSTAKERE,
+                status = Soknadstatus.NY,
+                sykmeldingId = sykmeldingUuid,
+            ).normaliser().soknad,
+        )
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -6,6 +6,7 @@ flex.syketilfelle.url: http://flex-syketilfelle
 
 DITT_SYKEFRAVAER_FRONTEND_CLIENT_ID: ditt-sykefravaer-frontend-client-id
 SYKEPENGESOKNAD_FRONTEND_CLIENT_ID: sykepengesoknad-frontend-client-id
+FLEX_SYKMELDINGER_BACKEND_TOKENX_CLIENT_ID: flex-sykmeldinger-backend-client-id
 SPINNTEKTSMELDING_FRONTEND_CLIENT_ID: spinntekstmelding-frontend-client-id
 TOKENX_IDPORTEN_IDP: idporten
 


### PR DESCRIPTION
## Beskrivelse
Nytt endepunkt som lar flex-sykmeldinger-backend sjekke om det eksisterer søknad for en gitt sykmelding (TokenX on-behalf-of).

## Endringer
- `GET /api/v2/soknader/sykmelding/{sykmeldingUuid}/harSoknad` — returnerer `{ harSoknad: boolean }`
- TokenX-autentisering, kun tillatt fra flex-sykmeldinger-backend
- Kaster 403 dersom søknaden tilhører annen bruker
- Inbound access policy oppdatert med flex-sykmeldinger-backend
- Implementert `findBySykmeldingUuid` i `SykepengesoknadRepositoryFake`
- Test med FakesTestOppsett (4 test-cases)

## Test-dekning
- ✅ harSoknad=true når søknad finnes
- ✅ harSoknad=false når ingen søknad finnes
- ✅ 403 når søknad tilhører annen bruker
- ✅ 401 uten token