### PR TITLE
Endre tillatt periode for LovMe-spørsmål

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/oppdatersporsmal/soknad/OppdaterSporsmalService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/oppdatersporsmal/soknad/OppdaterSporsmalService.kt
@@ -6,7 +6,15 @@ import no.nav.helse.flex.domain.Svar
 import no.nav.helse.flex.domain.Sykepengesoknad
 import no.nav.helse.flex.domain.flatten
 import no.nav.helse.flex.logger
-import no.nav.helse.flex.oppdatersporsmal.soknad.muteringer.*
+import no.nav.helse.flex.oppdatersporsmal.soknad.muteringer.arbeidGjenopptattMutering
+import no.nav.helse.flex.oppdatersporsmal.soknad.muteringer.brukteDuReisetilskuddetMutering
+import no.nav.helse.flex.oppdatersporsmal.soknad.muteringer.friskmeldtMuteringer
+import no.nav.helse.flex.oppdatersporsmal.soknad.muteringer.jobbaDuHundreGate
+import no.nav.helse.flex.oppdatersporsmal.soknad.muteringer.jobbsituasjonenDinMutering
+import no.nav.helse.flex.oppdatersporsmal.soknad.muteringer.naringsdrivendeErstattGamleSporsmalMutering
+import no.nav.helse.flex.oppdatersporsmal.soknad.muteringer.naringsdrivendeMutering
+import no.nav.helse.flex.oppdatersporsmal.soknad.muteringer.oppdaterMedSvarPaUtlandsopphold
+import no.nav.helse.flex.oppdatersporsmal.soknad.muteringer.utlandssoknadMuteringer
 import no.nav.helse.flex.repository.SvarDAO
 import no.nav.helse.flex.repository.SykepengesoknadDAO
 import no.nav.helse.flex.soknadsopprettelse.KVITTERINGER
@@ -138,18 +146,36 @@ class OppdaterSporsmalService(
         soknadId: String,
         tag: String,
     ) {
-        val soknad = sykepengesoknadDAO.finnSykepengesoknad(soknadId)
-        val sporsmal = soknad.sporsmal.first { it.tag == tag }
+        val sykepengesoknad = sykepengesoknadDAO.finnSykepengesoknad(soknadId)
+        val sporsmal = sykepengesoknad.sporsmal.first { it.tag == tag }
         val index = finnHoyesteIndex(sporsmal.undersporsmal) + 1
         val undersporsmal =
             when (tag) {
-                MEDLEMSKAP_UTFORT_ARBEID_UTENFOR_NORGE -> lagGruppertUndersporsmalTilSporsmalOmArbeidUtenforNorge(index, soknad.tom!!)
-                MEDLEMSKAP_OPPHOLD_UTENFOR_NORGE -> lagGruppertUndersporsmalTilSporsmalOmOppholdUtenforNorge(index, soknad.tom!!)
-                MEDLEMSKAP_OPPHOLD_UTENFOR_EOS -> lagGruppertUndersporsmalTilSporsmalOmOppholdUtenforEos(index, soknad.tom!!)
+                MEDLEMSKAP_UTFORT_ARBEID_UTENFOR_NORGE ->
+                    lagGruppertUndersporsmalTilSporsmalOmArbeidUtenforNorge(
+                        index,
+                        sykepengesoknad.fom!!,
+                        sykepengesoknad.tom!!,
+                    )
+
+                MEDLEMSKAP_OPPHOLD_UTENFOR_NORGE ->
+                    lagGruppertUndersporsmalTilSporsmalOmOppholdUtenforNorge(
+                        index,
+                        sykepengesoknad.fom!!,
+                        sykepengesoknad.tom!!,
+                    )
+
+                MEDLEMSKAP_OPPHOLD_UTENFOR_EOS ->
+                    lagGruppertUndersporsmalTilSporsmalOmOppholdUtenforEos(
+                        index,
+                        sykepengesoknad.fom!!,
+                        sykepengesoknad.tom!!,
+                    )
+
                 else -> throw IllegalArgumentException("Kan ikke legge til underspørsmål for tag $tag.")
             }
         val oppdatertSporsmal = sporsmal.copy(undersporsmal = sporsmal.undersporsmal + undersporsmal)
-        sykepengesoknadDAO.byttUtSporsmal(soknad.replaceSporsmal(oppdatertSporsmal))
+        sykepengesoknadDAO.byttUtSporsmal(sykepengesoknad.replaceSporsmal(oppdatertSporsmal))
     }
 
     fun slettUndersporsmal(

--- a/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/Arbeidstakere.kt
+++ b/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/Arbeidstakere.kt
@@ -84,21 +84,22 @@ fun settOppSoknadArbeidstaker(
                 when (it) {
                     LovMeSporsmalTag.OPPHOLDSTILATELSE -> {
                         lagSporsmalOmOppholdstillatelse(
+                            sykepengesoknad.fom,
                             sykepengesoknad.tom,
                             kjentOppholdstillatelse,
                         )
                     }
 
                     LovMeSporsmalTag.ARBEID_UTENFOR_NORGE -> {
-                        lagSporsmalOmArbeidUtenforNorge(sykepengesoknad.tom)
+                        lagSporsmalOmArbeidUtenforNorge(sykepengesoknad.fom, sykepengesoknad.tom)
                     }
 
                     LovMeSporsmalTag.OPPHOLD_UTENFOR_NORGE -> {
-                        lagSporsmalOmOppholdUtenforNorge(sykepengesoknad.tom)
+                        lagSporsmalOmOppholdUtenforNorge(sykepengesoknad.fom, sykepengesoknad.tom)
                     }
 
                     LovMeSporsmalTag.OPPHOLD_UTENFOR_EØS_OMRÅDE -> {
-                        lagSporsmalOmOppholdUtenforEos(sykepengesoknad.tom)
+                        lagSporsmalOmOppholdUtenforEos(sykepengesoknad.fom, sykepengesoknad.tom)
                     }
 
                     SykepengesoknadSporsmalTag.ARBEID_UTENFOR_NORGE -> {

--- a/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/sporsmal/medlemskap/MedlemskapSporsmal.kt
+++ b/src/main/kotlin/no/nav/helse/flex/soknadsopprettelse/sporsmal/medlemskap/MedlemskapSporsmal.kt
@@ -10,6 +10,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
 
 fun lagSporsmalOmOppholdstillatelse(
+    fom: LocalDate,
     tom: LocalDate,
     // kjentOppholdstillatelse skal aldri være null siden vi kaster exception hvis vi ikke mottar den sammen med
     // spørsmål om medlemskap OPPHOLDSTILLATELSE fra LovMe.
@@ -17,9 +18,11 @@ fun lagSporsmalOmOppholdstillatelse(
 ): Sporsmal =
     Sporsmal(
         tag = MEDLEMSKAP_OPPHOLDSTILLATELSE_V2,
-        sporsmalstekst = "Har Utlendingsdirektoratet gitt deg en oppholdstillatelse før ${DatoUtil.formatterDato(
-            kjentOppholdstillatelse?.fom!!,
-        )}?",
+        sporsmalstekst = "Har Utlendingsdirektoratet gitt deg en oppholdstillatelse før ${
+            DatoUtil.formatterDato(
+                kjentOppholdstillatelse?.fom!!,
+            )
+        }?",
         svartype = Svartype.JA_NEI,
         kriterieForVisningAvUndersporsmal = Visningskriterie.JA,
         undersporsmal =
@@ -30,21 +33,24 @@ fun lagSporsmalOmOppholdstillatelse(
                     svartype = Svartype.DATO,
                     // Vi vet ikke hvor lang tid tilbake en oppholdstillatelse kan ha bli gitt så vi setter 10 år i
                     // samarbeid med LovMe.
-                    min = tom.minusYears(10).format(ISO_LOCAL_DATE),
+                    min = formaterDato(tom.minusYears(10)),
                     // Vi vet at en vedtaksdato ikke kan være i fremtiden så vi setter dagens dato som maks.
-                    max = tom.format(ISO_LOCAL_DATE),
+                    max = formaterDato(tom),
                 ),
                 Sporsmal(
                     tag = MEDLEMSKAP_OPPHOLDSTILLATELSE_PERIODE,
                     sporsmalstekst = "Hvilken periode gjelder denne oppholdstillatelsen?",
                     svartype = Svartype.PERIODE,
-                    min = tom.minusYears(10).format(ISO_LOCAL_DATE),
-                    max = tom.plusYears(10).format(ISO_LOCAL_DATE),
+                    min = formaterDato(fom.minusYears(10)),
+                    max = formaterDato(tom.plusYears(10)),
                 ),
             ),
     )
 
-fun lagSporsmalOmArbeidUtenforNorge(tom: LocalDate): Sporsmal =
+fun lagSporsmalOmArbeidUtenforNorge(
+    fom: LocalDate,
+    tom: LocalDate,
+): Sporsmal =
     Sporsmal(
         tag = MEDLEMSKAP_UTFORT_ARBEID_UTENFOR_NORGE,
         sporsmalstekst = "Har du arbeidet utenfor Norge i løpet av de siste 12 månedene før du ble syk?",
@@ -52,7 +58,7 @@ fun lagSporsmalOmArbeidUtenforNorge(tom: LocalDate): Sporsmal =
         kriterieForVisningAvUndersporsmal = Visningskriterie.JA,
         undersporsmal =
             listOf(
-                lagGruppertUndersporsmalTilSporsmalOmArbeidUtenforNorge(0, tom),
+                lagGruppertUndersporsmalTilSporsmalOmArbeidUtenforNorge(0, fom, tom),
             ),
     )
 
@@ -63,6 +69,7 @@ fun medIndex(
 
 fun lagGruppertUndersporsmalTilSporsmalOmArbeidUtenforNorge(
     index: Int,
+    fom: LocalDate,
     tom: LocalDate,
 ): Sporsmal =
     Sporsmal(
@@ -87,14 +94,16 @@ fun lagGruppertUndersporsmalTilSporsmalOmArbeidUtenforNorge(
                     tag = medIndex(MEDLEMSKAP_UTFORT_ARBEID_UTENFOR_NORGE_NAAR, index),
                     sporsmalstekst = "I hvilken periode arbeidet du i utlandet?",
                     svartype = Svartype.PERIODE,
-                    // Til- og fra-dato er satt statisk i samarbeid med LovMe.
-                    min = tom.minusYears(10).format(ISO_LOCAL_DATE),
-                    max = tom.plusYears(1).format(ISO_LOCAL_DATE),
+                    min = formaterDato(fom.minusYears(1)),
+                    max = formaterDato(tom),
                 ),
             ),
     )
 
-fun lagSporsmalOmOppholdUtenforNorge(tom: LocalDate): Sporsmal =
+fun lagSporsmalOmOppholdUtenforNorge(
+    fom: LocalDate,
+    tom: LocalDate,
+): Sporsmal =
     Sporsmal(
         tag = MEDLEMSKAP_OPPHOLD_UTENFOR_NORGE,
         sporsmalstekst = "Har du oppholdt deg i utlandet i løpet av de siste 12 månedene før du ble syk?",
@@ -102,12 +111,13 @@ fun lagSporsmalOmOppholdUtenforNorge(tom: LocalDate): Sporsmal =
         kriterieForVisningAvUndersporsmal = Visningskriterie.JA,
         undersporsmal =
             listOf(
-                lagGruppertUndersporsmalTilSporsmalOmOppholdUtenforNorge(0, tom),
+                lagGruppertUndersporsmalTilSporsmalOmOppholdUtenforNorge(0, fom, tom),
             ),
     )
 
 fun lagGruppertUndersporsmalTilSporsmalOmOppholdUtenforNorge(
     index: Int,
+    fom: LocalDate,
     tom: LocalDate,
 ): Sporsmal =
     Sporsmal(
@@ -154,7 +164,11 @@ fun lagGruppertUndersporsmalTilSporsmalOmOppholdUtenforNorge(
                                 undersporsmal =
                                     listOf(
                                         Sporsmal(
-                                            tag = medIndex(MEDLEMSKAP_OPPHOLD_UTENFOR_NORGE_BEGRUNNELSE_ANNET_FRITEKST, index),
+                                            tag =
+                                                medIndex(
+                                                    MEDLEMSKAP_OPPHOLD_UTENFOR_NORGE_BEGRUNNELSE_ANNET_FRITEKST,
+                                                    index,
+                                                ),
                                             sporsmalstekst = "Beskriv hva du gjorde",
                                             svartype = Svartype.FRITEKST,
                                             min = "1",
@@ -168,14 +182,16 @@ fun lagGruppertUndersporsmalTilSporsmalOmOppholdUtenforNorge(
                     tag = medIndex(MEDLEMSKAP_OPPHOLD_UTENFOR_NORGE_NAAR, index),
                     sporsmalstekst = "I hvilken periode oppholdt du deg i dette landet?",
                     svartype = Svartype.PERIODE,
-                    // Til- og fra-dato er satt statisk i samarbeid med LovMe.
-                    min = tom.minusYears(2).format(ISO_LOCAL_DATE),
-                    max = tom.format(ISO_LOCAL_DATE),
+                    min = formaterDato(fom.minusYears(1)),
+                    max = formaterDato(tom),
                 ),
             ),
     )
 
-fun lagSporsmalOmOppholdUtenforEos(tom: LocalDate): Sporsmal =
+fun lagSporsmalOmOppholdUtenforEos(
+    fom: LocalDate,
+    tom: LocalDate,
+): Sporsmal =
     Sporsmal(
         tag = MEDLEMSKAP_OPPHOLD_UTENFOR_EOS,
         sporsmalstekst = "Har du oppholdt deg utenfor EU/EØS eller Sveits i løpet av de siste 12 månedene før du ble syk?",
@@ -183,12 +199,13 @@ fun lagSporsmalOmOppholdUtenforEos(tom: LocalDate): Sporsmal =
         kriterieForVisningAvUndersporsmal = Visningskriterie.JA,
         undersporsmal =
             listOf(
-                lagGruppertUndersporsmalTilSporsmalOmOppholdUtenforEos(0, tom),
+                lagGruppertUndersporsmalTilSporsmalOmOppholdUtenforEos(0, fom, tom),
             ),
     )
 
 fun lagGruppertUndersporsmalTilSporsmalOmOppholdUtenforEos(
     index: Int,
+    fom: LocalDate,
     tom: LocalDate,
 ): Sporsmal =
     Sporsmal(
@@ -235,7 +252,11 @@ fun lagGruppertUndersporsmalTilSporsmalOmOppholdUtenforEos(
                                 undersporsmal =
                                     listOf(
                                         Sporsmal(
-                                            tag = medIndex(MEDLEMSKAP_OPPHOLD_UTENFOR_EOS_BEGRUNNELSE_ANNET_FRITEKST, index),
+                                            tag =
+                                                medIndex(
+                                                    MEDLEMSKAP_OPPHOLD_UTENFOR_EOS_BEGRUNNELSE_ANNET_FRITEKST,
+                                                    index,
+                                                ),
                                             sporsmalstekst = "Beskriv hva du gjorde",
                                             svartype = Svartype.FRITEKST,
                                             min = "1",
@@ -249,9 +270,10 @@ fun lagGruppertUndersporsmalTilSporsmalOmOppholdUtenforEos(
                     tag = medIndex(MEDLEMSKAP_OPPHOLD_UTENFOR_EOS_NAAR, index),
                     sporsmalstekst = "I hvilken periode oppholdt du deg i dette landet?",
                     svartype = Svartype.PERIODE,
-                    // Til- og fra-dato er satt statisk i samarbeid med LovMe.
-                    min = tom.minusYears(2).format(ISO_LOCAL_DATE),
-                    max = tom.format(ISO_LOCAL_DATE),
+                    min = formaterDato(fom.minusYears(1)),
+                    max = formaterDato(tom),
                 ),
             ),
     )
+
+fun formaterDato(dato: LocalDate): String = dato.format(ISO_LOCAL_DATE)

--- a/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapSporsmalIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/medlemskap/MedlemskapSporsmalIntegrationTest.kt
@@ -8,6 +8,7 @@ import no.nav.helse.flex.controller.domain.sykepengesoknad.flatten
 import no.nav.helse.flex.domain.Arbeidssituasjon
 import no.nav.helse.flex.mockdispatcher.MedlemskapMockDispatcher
 import no.nav.helse.flex.soknadsopprettelse.*
+import no.nav.helse.flex.soknadsopprettelse.sporsmal.medlemskap.formaterDato
 import no.nav.helse.flex.soknadsopprettelse.sporsmal.medlemskap.medIndex
 import no.nav.helse.flex.sykepengesoknad.kafka.SoknadsstatusDTO
 import no.nav.helse.flex.sykepengesoknad.kafka.SoknadstypeDTO
@@ -24,7 +25,6 @@ import org.junit.jupiter.api.*
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.Instant
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
 
 /**
  * Tester at spørsmål om medlemskap blir opprettet og besvart som forventet, inkludert at
@@ -354,32 +354,32 @@ class MedlemskapSporsmalIntegrationTest : FellesTestOppsett() {
         val soknad = hentSoknadMedStatusNy()
 
         soknad.getSporsmalMedTag("MEDLEMSKAP_OPPHOLDSTILLATELSE_VEDTAKSDATO").also {
-            it.min shouldBeEqualTo tom.minusYears(10).format(ISO_LOCAL_DATE)
-            it.max shouldBeEqualTo tom.format(ISO_LOCAL_DATE)
+            it.min shouldBeEqualTo formaterDato(tom.minusYears(10))
+            it.max shouldBeEqualTo formaterDato(tom)
         }
         soknad.getSporsmalMedTag("MEDLEMSKAP_OPPHOLDSTILLATELSE_PERIODE").also {
-            it.min shouldBeEqualTo tom.minusYears(10).format(ISO_LOCAL_DATE)
-            it.max shouldBeEqualTo tom.plusYears(10).format(ISO_LOCAL_DATE)
+            it.min shouldBeEqualTo formaterDato(fom.minusYears(10))
+            it.max shouldBeEqualTo formaterDato(tom.plusYears(10))
         }
 
         val arbeidUtenforNorgePeriodeEn = soknad.getSporsmalMedTag("MEDLEMSKAP_UTFORT_ARBEID_UTENFOR_NORGE_NAAR_0")
         val arbeidUtenforNorgePeriodeTo = soknad.getSporsmalMedTag("MEDLEMSKAP_UTFORT_ARBEID_UTENFOR_NORGE_NAAR_1")
-        arbeidUtenforNorgePeriodeEn.min shouldBeEqualTo tom.minusYears(10).format(ISO_LOCAL_DATE)
-        arbeidUtenforNorgePeriodeEn.max shouldBeEqualTo tom.plusYears(1).format(ISO_LOCAL_DATE)
+        arbeidUtenforNorgePeriodeEn.min shouldBeEqualTo formaterDato(fom.minusYears(1))
+        arbeidUtenforNorgePeriodeEn.max shouldBeEqualTo formaterDato(tom)
         arbeidUtenforNorgePeriodeEn.min shouldBeEqualTo arbeidUtenforNorgePeriodeTo.min
         arbeidUtenforNorgePeriodeEn.max shouldBeEqualTo arbeidUtenforNorgePeriodeTo.max
 
         val oppholdUtenforNorgePeriodeEn = soknad.getSporsmalMedTag("MEDLEMSKAP_OPPHOLD_UTENFOR_NORGE_NAAR_0")
         val oppholdUtenforNorgePeriodeTo = soknad.getSporsmalMedTag("MEDLEMSKAP_OPPHOLD_UTENFOR_NORGE_NAAR_1")
-        oppholdUtenforNorgePeriodeEn.min shouldBeEqualTo tom.minusYears(2).format(ISO_LOCAL_DATE)
-        oppholdUtenforNorgePeriodeEn.max shouldBeEqualTo tom.format(ISO_LOCAL_DATE)
+        oppholdUtenforNorgePeriodeEn.min shouldBeEqualTo formaterDato(fom.minusYears(1))
+        oppholdUtenforNorgePeriodeEn.max shouldBeEqualTo formaterDato(tom)
         oppholdUtenforNorgePeriodeEn.min shouldBeEqualTo oppholdUtenforNorgePeriodeTo.min
         oppholdUtenforNorgePeriodeEn.max shouldBeEqualTo oppholdUtenforNorgePeriodeTo.max
 
         val oppholdUtenforEOSPeriodeEn = soknad.getSporsmalMedTag("MEDLEMSKAP_OPPHOLD_UTENFOR_EOS_NAAR_0")
         val oppholdUtenforEOSPeriodeTo = soknad.getSporsmalMedTag("MEDLEMSKAP_OPPHOLD_UTENFOR_EOS_NAAR_1")
-        oppholdUtenforEOSPeriodeEn.min shouldBeEqualTo tom.minusYears(2).format(ISO_LOCAL_DATE)
-        oppholdUtenforEOSPeriodeEn.max shouldBeEqualTo tom.format(ISO_LOCAL_DATE)
+        oppholdUtenforEOSPeriodeEn.min shouldBeEqualTo formaterDato(fom.minusYears(1))
+        oppholdUtenforEOSPeriodeEn.max shouldBeEqualTo formaterDato(tom)
         oppholdUtenforEOSPeriodeEn.min shouldBeEqualTo oppholdUtenforEOSPeriodeTo.min
         oppholdUtenforEOSPeriodeEn.max shouldBeEqualTo oppholdUtenforEOSPeriodeTo.max
     }

--- a/src/test/kotlin/no/nav/helse/flex/soknadsopprettelse/UnderersporsmalSortererTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/soknadsopprettelse/UnderersporsmalSortererTest.kt
@@ -127,7 +127,7 @@ class UnderersporsmalSortererTest {
 
     @Test
     fun `Test sortering av medlemskapspørsmål om oppholdstillatelse`() {
-        val sporsmalet = lagSporsmalOmOppholdstillatelse(LocalDate.now(), KjentOppholdstillatelse(LocalDate.now()))
+        val sporsmalet = lagSporsmalOmOppholdstillatelse(LocalDate.now(), LocalDate.now(), KjentOppholdstillatelse(LocalDate.now()))
         val soknad = sporsmalet.tilSoknad()
 
         val sporsmal = soknad.getSporsmalMedTag(MEDLEMSKAP_OPPHOLDSTILLATELSE_V2)
@@ -182,7 +182,7 @@ class UnderersporsmalSortererTest {
 
     @Test
     fun `Test sortering av medlemskapsørsmål om arbeid utenfor Norge`() {
-        val sporsmalet = lagSporsmalOmArbeidUtenforNorge(LocalDate.now())
+        val sporsmalet = lagSporsmalOmArbeidUtenforNorge(LocalDate.now(), LocalDate.now())
         val soknad = sporsmalet.tilSoknad()
 
         val soknadShufflet = soknad.shuffleSporsmalRekursivt()
@@ -204,12 +204,12 @@ class UnderersporsmalSortererTest {
     @Test
     fun `Test sortering av medlemskapspørsmål om arbeid utenfor Norge med to underspørsmål`() {
         val sporsmalet =
-            lagSporsmalOmArbeidUtenforNorge(LocalDate.now()).let {
+            lagSporsmalOmArbeidUtenforNorge(LocalDate.now(), LocalDate.now()).let {
                 it.copy(
                     undersporsmal =
                         it.undersporsmal +
                             listOf(
-                                lagGruppertUndersporsmalTilSporsmalOmArbeidUtenforNorge(1, LocalDate.now()),
+                                lagGruppertUndersporsmalTilSporsmalOmArbeidUtenforNorge(1, LocalDate.now(), LocalDate.now()),
                             ),
                 )
             }
@@ -255,7 +255,7 @@ class UnderersporsmalSortererTest {
 
     @Test
     fun `Test sortering av medlemskapspørsmål om opphold utenfor Norge`() {
-        val sporsmalet = lagSporsmalOmOppholdUtenforNorge(LocalDate.now())
+        val sporsmalet = lagSporsmalOmOppholdUtenforNorge(LocalDate.now(), LocalDate.now())
         val soknad = sporsmalet.tilSoknad()
 
         val soknadShufflet = soknad.shuffleSporsmalRekursivt()
@@ -292,7 +292,7 @@ class UnderersporsmalSortererTest {
 
     @Test
     fun `Test sortering av medlemskapspørsmål om opphold utenfor EØS`() {
-        val sporsmalet = lagSporsmalOmOppholdUtenforEos(LocalDate.now())
+        val sporsmalet = lagSporsmalOmOppholdUtenforEos(LocalDate.now(), LocalDate.now())
         val soknad = sporsmalet.tilSoknad()
 
         val soknadShufflet = soknad.shuffleSporsmalRekursivt()
@@ -345,15 +345,15 @@ class UnderersporsmalSortererTest {
     fun `Finn høyeste index til underspørsmål`() {
         finnHoyesteIndex(
             listOf(
-                lagGruppertUndersporsmalTilSporsmalOmArbeidUtenforNorge(0, LocalDate.now()),
+                lagGruppertUndersporsmalTilSporsmalOmArbeidUtenforNorge(0, LocalDate.now(), LocalDate.now()),
             ),
         ) `should be equal to` 0
 
         finnHoyesteIndex(
             listOf(
-                lagGruppertUndersporsmalTilSporsmalOmArbeidUtenforNorge(1, LocalDate.now()),
-                lagGruppertUndersporsmalTilSporsmalOmArbeidUtenforNorge(111, LocalDate.now()),
-                lagGruppertUndersporsmalTilSporsmalOmArbeidUtenforNorge(9, LocalDate.now()),
+                lagGruppertUndersporsmalTilSporsmalOmArbeidUtenforNorge(1, LocalDate.now(), LocalDate.now()),
+                lagGruppertUndersporsmalTilSporsmalOmArbeidUtenforNorge(111, LocalDate.now(), LocalDate.now()),
+                lagGruppertUndersporsmalTilSporsmalOmArbeidUtenforNorge(9, LocalDate.now(), LocalDate.now()),
             ),
         ) `should be equal to` 111
     }


### PR DESCRIPTION
Opprinnelig periode var satt på bakgrunn av antagelser når
funksjonaltiet ble laget. Input fra saksbehandlere gjør
at dette nå kan justeres, spesitl med tanke på at sykmeldt
nå ikke kan sette perioder frem i tid.
