### PR TITLE
Øk timeout på kall til flex-syketilfelle

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/config/AadRestTemplateConfiguration.kt
+++ b/src/main/kotlin/no/nav/helse/flex/config/AadRestTemplateConfiguration.kt
@@ -93,6 +93,8 @@ class AadRestTemplateConfiguration {
             restTemplateBuilder = restTemplateBuilder,
             clientConfigurationProperties = clientConfigurationProperties,
             oAuth2AccessTokenService = oAuth2AccessTokenService,
+            connectTimeout = Duration.ofSeconds(5),
+            readTimeout = Duration.ofSeconds(10),
         )
 
     @Bean


### PR DESCRIPTION
Hindrer timeout når flex-syketilfelle bruker lang tid på publisering
til etterlevelses-topic.
